### PR TITLE
Refactor shader API and improve LCD shaders

### DIFF
--- a/demos/bounce/index.html
+++ b/demos/bounce/index.html
@@ -196,16 +196,13 @@
 <script src="../../runtime/shader.js"></script>
 <script src="../../runtime/shaders/tint.js"></script>
 <script src="../../runtime/shaders/scanlines.js"></script>
+<script src="../../runtime/shaders/lcd.js"></script>
 <script src="../../runtime/shaders/lcd3d.js"></script>
 <script src="../../runtime/shaders/crt.js"></script>
 <script src="../../runtime/gamepad.js"></script>
 <script>
   Mono.boot("screen", { game: "game.lua", colors: 1 }).then(() => {
-    Mono.shader.enable("tint");
-    Mono.shader.enable("scanlines");
-    Mono.shader.enable("lcd3d");
-    Mono.shader.enable("crt");
-    Mono.shader.order(["tint", "scanlines", "lcd3d", "crt"]);
+    Mono.shader.preset();
   }).catch(e => console.error("Boot failed:", e));
 
 </script>

--- a/demos/shader-test/index.html
+++ b/demos/shader-test/index.html
@@ -6,6 +6,7 @@
 <link rel="icon" href="/favicon.png" type="image/png">
 <link rel="stylesheet" href="../../runtime/mono.css">
 <style>
+  body { height: auto; overflow: auto; }
   #controls {
     max-width: 640px;
     margin: 12px auto 0;
@@ -273,12 +274,14 @@ Mono.boot("screen", { game: "game.lua", colors: 4 }).then(() => {
   }
 
   // --- Add shader row ---
-  function addShaderRow(name) {
+  function addShaderRow(name, enabled) {
+    if (enabled === undefined) enabled = true;
     if (uiChain.indexOf(name) !== -1) return; // already in chain
 
     uiChain.push(name);
     syncChain();
     Mono.shader.enable(name);
+    if (!enabled) Mono.shader.disable(name);
 
     const row = document.createElement("div");
     row.className = "shader-row";
@@ -311,8 +314,9 @@ Mono.boot("screen", { game: "game.lua", colors: 4 }).then(() => {
     });
 
     const toggleBtn = document.createElement("button");
-    toggleBtn.className = "btn-toggle on";
-    toggleBtn.textContent = "on";
+    toggleBtn.className = enabled ? "btn-toggle on" : "btn-toggle off";
+    toggleBtn.textContent = enabled ? "on" : "off";
+    if (!enabled) row.classList.add("disabled");
     toggleBtn.addEventListener("click", () => {
       const isOn = toggleBtn.classList.contains("on");
       if (isOn) {
@@ -400,9 +404,10 @@ Mono.boot("screen", { game: "game.lua", colors: 4 }).then(() => {
   applyScale();
 
   addShaderRow("tint");
-  addShaderRow("scanlines");
-  addShaderRow("lcd3d");
-  addShaderRow("crt");
+  addShaderRow("scanlines", false);
+  addShaderRow("lcd");
+  addShaderRow("lcd3d", false);
+  addShaderRow("crt", false);
 
   updateInfo();
   window.addEventListener("resize", updateInfo);

--- a/editor/index.html
+++ b/editor/index.html
@@ -905,12 +905,13 @@
   <div class="ctx-item danger" id="ctx-delete">&#128465; Delete</div>
 </div>
 
-<script src="../runtime/engine.js?v=1"></script>
-<script src="../runtime/shader.js?v=1"></script>
-<script src="../runtime/shaders/tint.js?v=1"></script>
-<script src="../runtime/shaders/scanlines.js?v=1"></script>
-<script src="../runtime/shaders/lcd3d.js?v=1"></script>
-<script src="../runtime/shaders/crt.js?v=1"></script>
+<script src="../runtime/engine.js?v=2"></script>
+<script src="../runtime/shader.js?v=2"></script>
+<script src="../runtime/shaders/tint.js?v=2"></script>
+<script src="../runtime/shaders/scanlines.js?v=2"></script>
+<script src="../runtime/shaders/lcd.js?v=2"></script>
+<script src="../runtime/shaders/lcd3d.js?v=2"></script>
+<script src="../runtime/shaders/crt.js?v=2"></script>
 <script src="../runtime/console-log.js"></script>
 <script src="../runtime/console-screen.js"></script>
 <script src="../runtime/console-accel.js"></script>
@@ -1668,12 +1669,7 @@ async function start() {
     logToConsole("Running.", "log-info");
     document.getElementById("screen-body").focus();
 
-    // Default shader chain
-    Mono.shader.enable("tint");
-    Mono.shader.enable("scanlines");
-    Mono.shader.enable("lcd3d");
-    Mono.shader.enable("crt");
-    Mono.shader.order(["tint", "scanlines", "lcd3d", "crt"]);
+    Mono.shader.preset();
 
     if (fpsInterval) clearInterval(fpsInterval);
     fpsInterval = setInterval(updateFrame, 200);

--- a/playground/index.html
+++ b/playground/index.html
@@ -677,12 +677,13 @@
   </div>
 </div>
 
-<script src="../runtime/engine.js?v=14"></script>
-<script src="../runtime/shader.js?v=14"></script>
-<script src="../runtime/shaders/tint.js?v=14"></script>
-<script src="../runtime/shaders/scanlines.js?v=14"></script>
-<script src="../runtime/shaders/lcd3d.js?v=14"></script>
-<script src="../runtime/shaders/crt.js?v=14"></script>
+<script src="../runtime/engine.js?v=15"></script>
+<script src="../runtime/shader.js?v=15"></script>
+<script src="../runtime/shaders/tint.js?v=15"></script>
+<script src="../runtime/shaders/scanlines.js?v=15"></script>
+<script src="../runtime/shaders/lcd.js?v=15"></script>
+<script src="../runtime/shaders/lcd3d.js?v=15"></script>
+<script src="../runtime/shaders/crt.js?v=15"></script>
 <script src="../runtime/console-log.js"></script>
 <script src="../runtime/console-screen.js"></script>
 <script src="../runtime/console-accel.js"></script>
@@ -810,12 +811,7 @@ async function start() {
     logToConsole("Running.", "log-info");
     document.getElementById("screen-body").focus();
 
-    // Default shader chain
-    Mono.shader.enable("tint");
-    Mono.shader.enable("scanlines");
-    Mono.shader.enable("lcd3d");
-    Mono.shader.enable("crt");
-    Mono.shader.order(["tint", "scanlines", "lcd3d", "crt"]);
+    Mono.shader.preset();
 
     if (fpsInterval) clearInterval(fpsInterval);
     fpsInterval = setInterval(updateFrame, 200);

--- a/runtime/shader.js
+++ b/runtime/shader.js
@@ -4,12 +4,14 @@
  * Chain order: tint → lcd3d → crt (configurable)
  *
  * JS API:
- *   Mono.shader.enable("lcd3d", { opacity: 1.0 })
- *   Mono.shader.disable("lcd3d")
- *   Mono.shader.param("lcd3d", "opacity", 0.5)
- *   Mono.shader.tint([0.6, 0.9, 0.3])   // shortcut: enable tint
- *   Mono.shader.tint(null)               // shortcut: disable tint
- *   Mono.shader.order(["tint","lcd3d","crt"])  // set chain order
+ *   Mono.shader.enable("lcd3d")                     // register + enable
+ *   Mono.shader.enable("lcd3d", { depth: 0.5 })    // register + enable + params
+ *   Mono.shader.disable("lcd3d")                   // disable
+ *   Mono.shader.param("lcd3d", "depth", 0.5)
+ *   Mono.shader.tint([0.6, 0.9, 0.3])
+ *   Mono.shader.tint(null)
+ *   Mono.shader.order(["tint","lcd3d","crt"])
+ *   Mono.shader.preset()                          // standard set
  *   Mono.shader.register(name, glsl, defaults)
  *   Mono.shader.list()
  *   Mono.shader.current()
@@ -285,9 +287,6 @@ void main() {
     if (chain.indexOf(name) === -1) chain.push(name);
   };
 
-  // Keep for backwards compat
-  shader.registerEffect = shader.register;
-
   shader.enable = function (name, userParams) {
     if (!REGISTRY[name]) throw new Error("Unknown shader: " + name);
     initGL();
@@ -315,13 +314,15 @@ void main() {
       shader.disable("tint");
       return;
     }
-    initGL();
     shader.enable("tint", { tint: color });
   };
 
-  /** Convenience: enable a preset (backwards compat with old shader.use) */
-  shader.use = function (name, userParams) {
-    shader.enable(name, userParams);
+
+  /** Standard shader preset: tint (amber) → lcd */
+  shader.preset = function () {
+    shader.enable("tint", { tint: [1.0, 0.75, 0.3] });
+    shader.enable("lcd", { bg_color: [0, 0, 0], bg_color2: [0.19, 0.19, 0.19] });
+    shader.order(["tint", "lcd"]);
   };
 
   /** Disable all */

--- a/runtime/shaders/lcd.js
+++ b/runtime/shaders/lcd.js
@@ -29,4 +29,4 @@ void main() {
     vec3 bg = mix(u_bg_color, u_bg_color2, clamp(t, 0.0, 1.0));
     gl_FragColor = vec4(bg, 1.0);
   }
-}`, { thickness: 0.20, pixel_size: 1.0, bg_color: [0, 0, 0], bg_color2: [0, 0, 0], bg_dir: 0.0 });
+}`, { thickness: 0.20, pixel_size: 1.0, bg_color: [0, 0, 0], bg_color2: [0.19, 0.19, 0.19], bg_dir: 0.0});

--- a/runtime/shaders/lcd3d.js
+++ b/runtime/shaders/lcd3d.js
@@ -1,6 +1,6 @@
 /**
  * Mono Shader: LCD 3D
- * Background + isolated pixels with bevel/emboss depth.
+ * Background + isolated pixels with drop shadow.
  * Params: thickness (0-0.5), depth (0-1), pixel_size (0.5+, default 1),
  *         bg_color/bg_color2 ([r,g,b] 0-1), bg_dir (0-1, angle)
  */
@@ -23,23 +23,30 @@ void main() {
   bool inPixel = edge.x >= half_t && edge.x <= (1.0 - half_t)
               && edge.y >= half_t && edge.y <= (1.0 - half_t);
   bool isZero = (color.r + color.g + color.b) <= 0.0;
-  if (!inPixel || isZero) {
+
+  if (inPixel && !isZero) {
+    gl_FragColor = color;
+  } else {
+    // Background gradient
     float angle = u_bg_dir * 6.28318;
     float t = dot(v_uv - 0.5, vec2(sin(angle), cos(angle))) + 0.5;
     vec3 bg = mix(u_bg_color, u_bg_color2, clamp(t, 0.0, 1.0));
+
+    // Drop shadow: sample pixel to upper-left (shadow casts to lower-right)
+    vec2 shadowOffset = vec2(u_depth * 0.4, -u_depth * 0.4) / u_resolution;
+    vec4 srcColor = texture2D(u_tex, v_uv - shadowOffset);
+    bool srcLit = (srcColor.r + srcColor.g + srcColor.b) > 0.0;
+
+    // Check if that source pixel would be "inPixel" at the offset position
+    vec2 srcPixel = (v_uv - shadowOffset) * u_resolution / u_pixel_size;
+    vec2 srcEdge = fract(srcPixel);
+    bool srcInPixel = srcEdge.x >= half_t && srcEdge.x <= (1.0 - half_t)
+                   && srcEdge.y >= half_t && srcEdge.y <= (1.0 - half_t);
+
+    if (srcLit && srcInPixel) {
+      bg *= (1.0 - u_depth * 0.5);
+    }
+
     gl_FragColor = vec4(bg, 1.0);
-  } else {
-    float bw = u_thickness;
-    bool nearLeft = edge.x < half_t + bw;
-    bool nearTop  = edge.y < half_t + bw;
-    bool nearRight  = edge.x > 1.0 - half_t - bw;
-    bool nearBottom = edge.y > 1.0 - half_t - bw;
-    if (nearLeft || nearTop) {
-      color.rgb += u_depth * 0.15;
-    }
-    if (nearRight || nearBottom) {
-      color.rgb -= u_depth * 0.15;
-    }
-    gl_FragColor = color;
   }
-}`, { thickness: 0.20, pixel_size: 1.0, depth: 1.0, bg_color: [0, 0, 0], bg_color2: [0, 0, 0], bg_dir: 0.0 });
+}`, { thickness: 0.20, pixel_size: 1.0, depth: 1.0, bg_color: [0, 0, 0], bg_color2: [0.19, 0.19, 0.19], bg_dir: 0.0});


### PR DESCRIPTION
## Changes

### Shader API Refactoring
- Remove `add()` method and `registerEffect` alias
- Restore `enable()` and `disable()` as primary methods
- Add `preset()` for standard shader configuration (tint + lcd)
- Update all demos and editors to use new `preset()` method

### LCD Shader Improvements
- Skip rendering zero-value pixels in both `lcd.js` and `lcd3d.js`
- Replace bevel/emboss effect with drop shadow in `lcd3d.js`
- Adjust background color defaults to `[0.19, 0.19, 0.19]` for better contrast
- Update shader-test demo to show disabled shaders by default

### Other Updates
- Update cache-busting version numbers in editor and playground
- Add `lcd.js` script references where missing
- Improve shader-test UI scrolling