### PR TITLE
fix: add surface ID to default main.lua template

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -1046,6 +1046,8 @@ async function openFolder(droppedHandle) {
       const hello = `-- My Mono Game
 -- 160x144, Lua 5.4
 
+local scr = screen()
+
 function _init()
   mode(1) -- 1=2 colors, 2=4 colors, 4=16 colors
 end
@@ -1059,9 +1061,9 @@ function _update()
 end
 
 function _draw()
-  cls(0)
-  text("HELLO MONO!", 44, 66, 1)
-  rect(0, 0, SCREEN_W, SCREEN_H, 1)
+  cls(scr, 0)
+  text(scr, "HELLO MONO!", 44, 66, 1)
+  rect(scr, 0, 0, SCREEN_W, SCREEN_H, 1)
 end
 `;
       await writable.write(hello);


### PR DESCRIPTION
## Summary
- Fix default `main.lua` template to include `local scr = screen()` and pass surface ID as first arg to `cls`, `text`, `rect`
- New users no longer see a blank screen on first run

## Test plan
- [x] Open editor, create new project → verify `main.lua` includes `local scr = screen()` and surface IDs
- [x] Run the generated template → verify "HELLO MONO!" renders correctly

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)