### PR TITLE
feat: add text alignment to text()

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -345,12 +345,19 @@ All sprite drawing functions are affected by camera.
 ### Text
 
 ```lua
-text(surface, str, x, y, color)
+text(surface, str, x, y, color [, align])
 ```
 
 - 4x7 pixel bitmap font, 5px character pitch (4px glyph + 1px gap)
 - Uppercase only (auto-converted)
 - Supports: A-Z, 0-9, space, `.` `,` `!` `?` `-` `+` `:` `/` `*` `#` `(` `)` `=` `'` `"` `<` `>` `_`
+- `align` (optional, bit flags — default `ALIGN_LEFT`):
+  - `ALIGN_LEFT` (0) — default
+  - `ALIGN_HCENTER` (1) — x is the horizontal center
+  - `ALIGN_RIGHT` (2) — x is the right edge
+  - `ALIGN_VCENTER` (4) — y is the vertical center
+  - `ALIGN_CENTER` (5) — `ALIGN_HCENTER + ALIGN_VCENTER`
+  - Combine with `+`: `ALIGN_RIGHT + ALIGN_VCENTER`
 - **NOT affected by camera** -- always draws at screen coordinates
 
 ---

--- a/editor/index.html
+++ b/editor/index.html
@@ -1187,7 +1187,7 @@ async function openFolder(droppedHandle) {
   logToConsole("Opened: " + dirHandle.name, "log-info");
 }
 
-const MONO_VERSION = "0.3.9";
+const MONO_VERSION = "0.3.11";
 document.title = `Mono Editor v${MONO_VERSION}`;
 
 async function monoContext() {

--- a/editor/templates/mono/main.lua
+++ b/editor/templates/mono/main.lua
@@ -17,6 +17,6 @@ end
 
 function _draw()
   cls(scr, 0)
-  text(scr, "HELLO MONO!", 44, 66, 1)
+  text(scr, "HELLO MONO!", SCREEN_W/2, SCREEN_H/2, 1, ALIGN_CENTER)
   rect(scr, 0, 0, SCREEN_W, SCREEN_H, 1)
 end

--- a/editor/templates/mono/mono-test.js
+++ b/editor/templates/mono/mono-test.js
@@ -253,8 +253,15 @@ function circf(s, cx, cy, r, c) {
   }
 }
 
-function drawText(s, str, x, y, c) {
+const ALIGN_LEFT = 0, ALIGN_HCENTER = 1, ALIGN_RIGHT = 2, ALIGN_VCENTER = 4, ALIGN_CENTER = 5;
+
+function drawText(s, str, x, y, c, align) {
   str = String(str).toUpperCase();
+  align = align || 0;
+  const textW = str.length * (FONT_W + 1) - 1;
+  if (align & ALIGN_HCENTER) x = x - textW / 2;
+  else if (align & ALIGN_RIGHT) x = x - textW;
+  if (align & ALIGN_VCENTER) y = y - FONT_H / 2;
   let cx = Math.floor(x);
   const cy = Math.floor(y);
   for (const ch of str) {
@@ -464,6 +471,11 @@ async function main() {
   lua.global.set("SCREEN_W", W);
   lua.global.set("SCREEN_H", H);
   lua.global.set("COLORS", palette.length);
+  lua.global.set("ALIGN_LEFT", ALIGN_LEFT);
+  lua.global.set("ALIGN_HCENTER", ALIGN_HCENTER);
+  lua.global.set("ALIGN_RIGHT", ALIGN_RIGHT);
+  lua.global.set("ALIGN_VCENTER", ALIGN_VCENTER);
+  lua.global.set("ALIGN_CENTER", ALIGN_CENTER);
   // Drawing functions — first arg is surface id
   lua.global.set("cls", (id, c) => { const s = getSurf(id); if (s) cls(s, c); });
   lua.global.set("pix", (id, x, y, c) => { const s = getSurf(id); if (s) setPix(s, Math.floor(x) - camX, Math.floor(y) - camY, c); });
@@ -473,7 +485,7 @@ async function main() {
   lua.global.set("rectf", (id, x, y, w, h, c) => { const s = getSurf(id); if (s) rectf(s, x, y, w, h, c); });
   lua.global.set("circ", (id, cx, cy, r, c) => { const s = getSurf(id); if (s) circ(s, cx, cy, r, c); });
   lua.global.set("circf", (id, cx, cy, r, c) => { const s = getSurf(id); if (s) circf(s, cx, cy, r, c); });
-  lua.global.set("text", (id, str, x, y, c) => { const s = getSurf(id); if (s) drawText(s, str, x, y, c); });
+  lua.global.set("text", (id, str, x, y, c, align) => { const s = getSurf(id); if (s) drawText(s, str, x, y, c, align); });
   lua.global.set("cam", camFn);
   lua.global.set("_cam_get_x", () => camX);
   lua.global.set("_cam_get_y", () => camY);

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -254,8 +254,15 @@ var Mono = (() => {
     if (debugMode) debugShapes.push({ x: cx - r, y: cy - r, w: r * 2 + 1, h: r * 2 + 1 });
   }
 
-  function drawText(s, str, x, y, c) {
+  const ALIGN_LEFT = 0, ALIGN_HCENTER = 1, ALIGN_RIGHT = 2, ALIGN_VCENTER = 4, ALIGN_CENTER = 5;
+
+  function drawText(s, str, x, y, c, align) {
     str = String(str).toUpperCase();
+    align = align || 0;
+    const textW = str.length * (FONT_W + 1) - 1;
+    if (align & ALIGN_HCENTER) x = x - textW / 2;
+    else if (align & ALIGN_RIGHT) x = x - textW;
+    if (align & ALIGN_VCENTER) y = y - FONT_H / 2;
     let cx = Math.floor(x);
     const cy = Math.floor(y);
     for (const ch of str) {
@@ -512,6 +519,11 @@ var Mono = (() => {
     lua.global.set("SCREEN_W", W);
     lua.global.set("SCREEN_H", H);
     lua.global.set("COLORS", palette.length);
+    lua.global.set("ALIGN_LEFT", ALIGN_LEFT);
+    lua.global.set("ALIGN_HCENTER", ALIGN_HCENTER);
+    lua.global.set("ALIGN_RIGHT", ALIGN_RIGHT);
+    lua.global.set("ALIGN_VCENTER", ALIGN_VCENTER);
+    lua.global.set("ALIGN_CENTER", ALIGN_CENTER);
     // Drawing functions — first arg is surface id
     lua.global.set("cls", (id, c) => { checkColor(c, "cls"); const s = getSurf(id); if (s) cls(s, c); });
     lua.global.set("pix", (id, x, y, c) => { checkColor(c, "pix"); const s = getSurf(id); if (s) setPix(s, Math.floor(x) - camX, Math.floor(y) - camY, c); });
@@ -521,7 +533,7 @@ var Mono = (() => {
     lua.global.set("rectf", (id, x, y, w, h, c) => { checkColor(c, "rectf"); const s = getSurf(id); if (s) rectf(s, x, y, w, h, c); });
     lua.global.set("circ", (id, cx, cy, r, c) => { checkColor(c, "circ"); const s = getSurf(id); if (s) circ(s, cx, cy, r, c); });
     lua.global.set("circf", (id, cx, cy, r, c) => { checkColor(c, "circf"); const s = getSurf(id); if (s) circf(s, cx, cy, r, c); });
-    lua.global.set("text", (id, str, x, y, c) => { checkColor(c, "text"); const s = getSurf(id); if (s) drawText(s, str, x, y, c); });
+    lua.global.set("text", (id, str, x, y, c, align) => { checkColor(c, "text"); const s = getSurf(id); if (s) drawText(s, str, x, y, c, align); });
     lua.global.set("cam", cam);
     lua.global.set("_cam_get_x", () => camX);
     lua.global.set("_cam_get_y", () => camY);


### PR DESCRIPTION
## Summary
- Add optional `align` parameter to `text()` using bit flag constants
- Engine exposes Lua globals: `ALIGN_LEFT(0)`, `ALIGN_HCENTER(1)`, `ALIGN_RIGHT(2)`, `ALIGN_VCENTER(4)`, `ALIGN_CENTER(5)`
- Flags are combinable: `ALIGN_RIGHT + ALIGN_VCENTER`
- Update hello world template to use `ALIGN_CENTER` for perfect centering
- Sync changes across engine.js, mono-test.js, and DEV.md

Closes #20

## Usage
```lua
text(scr, "GAME OVER", SCREEN_W/2, SCREEN_H/2, 15, ALIGN_CENTER)
text(scr, "SCORE: 100", SCREEN_W - 2, 2, 1, ALIGN_RIGHT)
text(scr, "LEFT ALIGNED", 10, 10, 1) -- default, no flag needed
```

## Test plan
- [x] mono-test.js ASCII output confirms left/hcenter/right/vcenter/center alignment
- [x] Backward compatible — omitting align defaults to left
- [x] Editor hello world template uses ALIGN_CENTER
- [x] Existing games unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)