### PR TITLE
feat: clean up DEV.md, implement cam_shake and audio

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -103,6 +103,7 @@ Open `http://localhost:8000` in a browser.
 | Sprite size     | 16 x 16 pixels (default)                        |
 | Frame rate      | 30 FPS                                          |
 | Input           | 8 buttons: up, down, left, right, a, b, start, select |
+| Audio           | 2 channels, square wave                         |
 | Language        | Lua 5.4 via Wasmoon                             |
 
 ### Graphics Mode

--- a/editor/index.html
+++ b/editor/index.html
@@ -1187,7 +1187,7 @@ async function openFolder(droppedHandle) {
   logToConsole("Opened: " + dirHandle.name, "log-info");
 }
 
-const MONO_VERSION = "0.3.21";
+const MONO_VERSION = "0.3.22";
 document.title = `Mono Editor v${MONO_VERSION}`;
 
 async function monoContext() {

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -64,7 +64,8 @@ var Mono = (() => {
     osc.frequency.value = freq;
     gain.gain.value = 0.15;
     // Fade out at end to avoid clicks
-    gain.gain.setValueAtTime(0.15, ctx.currentTime + dur - Math.min(0.02, dur * 0.5));
+    const fadeStart = Math.max(ctx.currentTime, ctx.currentTime + dur - 0.02);
+    gain.gain.setValueAtTime(0.15, fadeStart);
     gain.gain.linearRampToValueAtTime(0, ctx.currentTime + dur);
     osc.connect(gain);
     gain.connect(ctx.destination);


### PR DESCRIPTION
## Summary
- Remove all unimplemented APIs from DEV.md (ECS, tween, tilemap, defSprite, bgm, RAM, etc.)
- Document previously undocumented APIs (ALIGN_*, axis_x/y, imageWidth/Height, print, vrow/vdump)
- Implement `cam_reset()` and `cam_shake(amount)` with 0.9x decay
- Implement `note(channel, noteStr, duration)` — 2-channel square wave via Web Audio
- Implement `sfx_stop([channel])` — stop one or all channels

Closes #13

## Test plan
- [x] Editor: `note(0, "C4", 0.1)` plays a beep
- [x] Editor: `cam_shake(10)` shakes the screen
- [x] DEV.md only documents APIs that exist in engine.js
- [x] Existing demos unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)