### PR TITLE
Define ALPHA project stage and root-cause rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,9 @@ Mono is a constraint-driven fantasy game console (160x144, 16 grayscale colors, 
 ## Rules
 
 ### When AI makes a mistake
-- Record the bug pattern in `docs/AI-PITFALLS.md`
-- Format: Symptom, Cause, Fix with code examples
-- This document is referenced in future prompts to prevent the same mistake
+- First, fix the root cause — if the API is confusing, rename it; if a return type is ambiguous, change it
+- Only document in `docs/AI-PITFALLS.md` when the root cause cannot be fixed (e.g. Lua language limitations, Wasmoon quirks)
+- We are in ALPHA — prefer changing the engine over teaching AI to work around bad design
 
 ### Lua specifics (Wasmoon)
 - Lua 5.4, NOT Luau — no type annotations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,24 @@
 # Mono — Claude Code Project Instructions
 
+## Project Stage: ALPHA (Engine Development)
+
+Current focus: engine development + first-party game for Play Store release.
+
+### Stage Rules
+- NO backward compatibility — break anything freely
+- NO deprecation warnings or migration guides
+- NO defensive coding for external consumers
+- API changes are expected and encouraged
+- Optimize for speed of iteration, not stability
+
+### Stage Roadmap
+```
+ALPHA   (now)  Engine development     — no external users, break freely
+BETA           Online editor          — API stabilization begins
+GAMMA          Publishing system      — backward compatibility starts
+PUBLIC         User pages & community — stability required
+```
+
 ## Project
 Mono is a constraint-driven fantasy game console (160x144, 16 grayscale colors, 16x16 sprites, Lua 5.4 via Wasmoon).
 


### PR DESCRIPTION
## Summary

Introduces a project-stage concept in `CLAUDE.md` so AI assistants adapt their behavior to the current phase of the project, plus a guideline to prefer engine fixes over documenting AI pitfalls.

## Changes

- **Project Stage: ALPHA** — current stage declared in CLAUDE.md. Stage rules tell AI to break freely, skip backward compatibility concerns, skip deprecation warnings, and optimize for iteration speed over stability.
- **Stage roadmap** — ALPHA (engine dev) → BETA (online editor) → GAMMA (publishing) → PUBLIC (community). Transitions flip the rules.
- **Root-cause rule** — when AI makes a mistake, prefer fixing the engine (rename confusing APIs, change return types) over adding entries to `AI-PITFALLS.md`. Only document pitfalls that cannot be fixed at the source (Lua language limits, Wasmoon quirks).
- **HEADLESS-TEST-IDEAS.md** — a memo of 9 enhancement ideas for the headless test runner, grouped by stage (ALPHA / BETA / GAMMA).

## Why

Previously the AI repeatedly asked about hidden costs like "do we need to keep X for backward compatibility?" during engine refactors, wasting tokens on concerns that don't apply in ALPHA. A one-line stage declaration removes that friction and lets the same CLAUDE.md flip into stricter modes later by changing one line.

## Test Plan

- [x] CLAUDE.md renders correctly and contains the new stage section
- [x] AI assistants pick up the stage rules on next context load
- [ ] Manually flip stage to BETA in a future PR and confirm behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)