### PR TITLE
Gamepad controls with collapsible panel

### DIFF
--- a/design/mono.pen
+++ b/design/mono.pen
@@ -933,49 +933,87 @@
           "fill": "#0a0a0a",
           "padding": [
             0,
-            16
+            12
           ],
           "justifyContent": "space_between",
           "alignItems": "center",
           "children": [
             {
+              "type": "text",
+              "id": "clG9m",
+              "name": "emoji",
+              "fill": "#555555",
+              "content": "✚ ·•",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            },
+            {
               "type": "frame",
-              "id": "rBNLQ",
-              "name": "ToggleLabel",
-              "gap": 8,
+              "id": "bK8CM",
+              "name": "btnGroup",
+              "gap": 6,
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
-                  "id": "tWCV1",
-                  "name": "gpEye",
-                  "width": 14,
-                  "height": 14,
-                  "iconFontName": "eye",
-                  "iconFontFamily": "lucide",
-                  "fill": "#aaaaaa"
+                  "type": "frame",
+                  "id": "DjftG",
+                  "name": "selBtn",
+                  "fill": "#222222",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "OKWJF",
+                      "fill": "#666666",
+                      "content": "SELECT",
+                      "fontFamily": "Inter",
+                      "fontSize": 8,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    }
+                  ]
                 },
                 {
-                  "type": "text",
-                  "id": "YDcwY",
-                  "name": "gpTxt",
-                  "fill": "#aaaaaa",
-                  "content": "Show gamepad",
-                  "fontFamily": "Inter",
-                  "fontSize": 11,
-                  "fontWeight": "600"
+                  "type": "frame",
+                  "id": "ae68L",
+                  "name": "startBtn",
+                  "fill": "#222222",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "3qLzg",
+                      "fill": "#666666",
+                      "content": "START",
+                      "fontFamily": "Inter",
+                      "fontSize": 8,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    }
+                  ]
                 }
               ]
             },
             {
               "type": "icon_font",
-              "id": "GhTYg",
-              "name": "gpChev",
+              "id": "D4uJz",
+              "name": "expand",
               "width": 14,
               "height": 14,
               "iconFontName": "chevron-down",
               "iconFontFamily": "lucide",
-              "fill": "#666666"
+              "fill": "#555555"
             }
           ]
         },
@@ -7628,6 +7666,7 @@
               "content": "Developer",
               "fontFamily": "Inter",
               "fontSize": 14,
+              "fontWeight": "normal",
               "letterSpacing": 2
             }
           ]
@@ -7680,7 +7719,8 @@
                   "fill": "#555555",
                   "content": "you@example.com",
                   "fontFamily": "Inter",
-                  "fontSize": 14
+                  "fontSize": 14,
+                  "fontWeight": "normal"
                 }
               ]
             },
@@ -7720,7 +7760,8 @@
                   "fill": "#555555",
                   "content": "••••••••",
                   "fontFamily": "Inter",
-                  "fontSize": 14
+                  "fontSize": 14,
+                  "fontWeight": "normal"
                 }
               ]
             },
@@ -7896,7 +7937,8 @@
               "fill": "#666666",
               "content": "Don't have an account?",
               "fontFamily": "Inter",
-              "fontSize": 12
+              "fontSize": 12,
+              "fontWeight": "normal"
             },
             {
               "type": "text",
@@ -7963,6 +8005,7 @@
               "content": "Create Account",
               "fontFamily": "Inter",
               "fontSize": 14,
+              "fontWeight": "normal",
               "letterSpacing": 2
             }
           ]
@@ -8259,7 +8302,8 @@
               "fill": "#666666",
               "content": "Already have an account?",
               "fontFamily": "Inter",
-              "fontSize": 12
+              "fontSize": 12,
+              "fontWeight": "normal"
             },
             {
               "type": "text",
@@ -9441,6 +9485,205 @@
                   "fontFamily": "Inter",
                   "fontSize": 11,
                   "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "Hiqpb",
+      "x": 2400,
+      "y": 1260,
+      "name": "Gamepad Expanded",
+      "width": 390,
+      "height": 160,
+      "fill": "#0a0a0a",
+      "cornerRadius": [
+        0,
+        0,
+        24,
+        24
+      ],
+      "layout": "vertical",
+      "gap": 8,
+      "padding": [
+        8,
+        16,
+        16,
+        16
+      ],
+      "children": [
+        {
+          "type": "frame",
+          "id": "tp3wJ",
+          "name": "topRow",
+          "width": "fill_container",
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "GC8m2",
+              "fill": "#555555",
+              "content": "✚ ·•",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "wyZGS",
+              "name": "btnGrp",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "G9iks",
+                  "name": "sel",
+                  "fill": "#222222",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Sq9vu",
+                      "fill": "#666666",
+                      "content": "SELECT",
+                      "fontFamily": "Inter",
+                      "fontSize": 8,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "35MeN",
+                  "name": "sta",
+                  "fill": "#222222",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rzS53",
+                      "fill": "#666666",
+                      "content": "START",
+                      "fontFamily": "Inter",
+                      "fontSize": 8,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "icon_font",
+              "id": "vQDmA",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "chevron-up",
+              "iconFontFamily": "lucide",
+              "fill": "#555555"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "BQ0gv",
+          "name": "padRow",
+          "width": "fill_container",
+          "height": "fill_container",
+          "padding": [
+            0,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "gysrY",
+              "name": "DPad",
+              "width": 80,
+              "height": 80,
+              "layout": "none",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "J4HgS",
+                  "x": 0,
+                  "y": 27,
+                  "name": "dpadH",
+                  "width": 80,
+                  "height": 26,
+                  "fill": "#2a2a2a",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "lDBMf",
+                  "x": 27,
+                  "y": 0,
+                  "name": "dpadV",
+                  "width": 26,
+                  "height": 80,
+                  "fill": "#2a2a2a",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ojyuT",
+                  "x": 29,
+                  "y": 29,
+                  "name": "dpadC",
+                  "width": 22,
+                  "height": 22,
+                  "fill": "#1a1a1a",
+                  "cornerRadius": 3
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "EIIwY",
+              "name": "ABButtons",
+              "width": 103,
+              "height": 77,
+              "layout": "none",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "T3OK0",
+                  "x": 0,
+                  "y": 32.5,
+                  "name": "btnB",
+                  "fill": "#2a2a2a",
+                  "width": 40,
+                  "height": 40
+                },
+                {
+                  "type": "ellipse",
+                  "id": "IJ3hD",
+                  "x": 59,
+                  "y": 0.5,
+                  "name": "btnA",
+                  "fill": "#e8e8e8",
+                  "width": 44,
+                  "height": 44
                 }
               ]
             }

--- a/design/mono.pen
+++ b/design/mono.pen
@@ -9527,6 +9527,7 @@
             {
               "type": "text",
               "id": "GC8m2",
+              "opacity": 0,
               "fill": "#555555",
               "content": "✚ ·•",
               "fontFamily": "Inter",
@@ -9662,14 +9663,14 @@
               "id": "EIIwY",
               "name": "ABButtons",
               "width": 103,
-              "height": 77,
+              "height": "fill_container",
               "layout": "none",
               "children": [
                 {
                   "type": "ellipse",
                   "id": "T3OK0",
                   "x": 0,
-                  "y": 32.5,
+                  "y": 49,
                   "name": "btnB",
                   "fill": "#2a2a2a",
                   "width": 40,
@@ -9679,7 +9680,7 @@
                   "type": "ellipse",
                   "id": "IJ3hD",
                   "x": 59,
-                  "y": 0.5,
+                  "y": 17,
                   "name": "btnA",
                   "fill": "#e8e8e8",
                   "width": 44,

--- a/dev/index.html
+++ b/dev/index.html
@@ -609,11 +609,13 @@
   .gamepad-dpad-left { top: 27px; left: 0; width: 27px; height: 26px; }
   .gamepad-dpad-right { top: 27px; right: 0; width: 27px; height: 26px; }
   .gamepad-ab {
-    display: flex;
-    gap: 6px;
-    align-items: flex-end;
+    position: relative;
+    width: 103px;
+    height: 90px;
   }
   .gamepad-btn-b {
+    position: absolute;
+    left: 0; bottom: 0;
     width: 40px; height: 40px;
     border-radius: 20px;
     background: #2a2a2a;
@@ -622,6 +624,8 @@
   }
   .gamepad-btn-b:active { background: #444; }
   .gamepad-btn-a {
+    position: absolute;
+    right: 0; top: 0;
     width: 44px; height: 44px;
     border-radius: 22px;
     background: #e8e8e8;

--- a/dev/index.html
+++ b/dev/index.html
@@ -519,18 +519,116 @@
   .console-dot.off { background: #2a2a2a; }
   .console-dot.on { background: #6c6; }
 
-  .editor-gamepad-toggle {
+  .gamepad-bar {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 8px 16px;
-    font-size: 11px;
-    color: #888;
-    background: #000;
+    justify-content: space-between;
+    padding: 0 12px;
+    height: 36px;
+    background: #0a0a0a;
     border-top: 1px solid #1a1a1a;
     flex-shrink: 0;
   }
-  .editor-gamepad-toggle svg { width: 14px; height: 14px; }
+  .gamepad-bar-icon { font-size: 11px; color: #555; }
+  .gamepad-bar-btns {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+  .gamepad-btn {
+    background: #222;
+    border: none;
+    border-radius: 4px;
+    color: #666;
+    font-family: 'Inter', sans-serif;
+    font-size: 8px;
+    font-weight: 600;
+    letter-spacing: 1px;
+    padding: 4px 10px;
+    cursor: pointer;
+  }
+  .gamepad-btn:hover { background: #333; }
+  .gamepad-btn:active { background: #444; color: #eee; }
+  .gamepad-expand {
+    background: none;
+    border: none;
+    color: #555;
+    cursor: pointer;
+    padding: 4px;
+  }
+
+  .gamepad-panel {
+    display: none;
+    background: #0a0a0a;
+    padding: 8px 16px 16px;
+    flex-shrink: 0;
+  }
+  .gamepad-panel.show { display: block; }
+  .gamepad-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    padding: 8px 16px;
+  }
+  .gamepad-dpad {
+    position: relative;
+    width: 80px;
+    height: 80px;
+  }
+  .gamepad-dpad-h {
+    position: absolute;
+    top: 27px; left: 0;
+    width: 80px; height: 26px;
+    background: #2a2a2a;
+    border-radius: 4px;
+  }
+  .gamepad-dpad-v {
+    position: absolute;
+    top: 0; left: 27px;
+    width: 26px; height: 80px;
+    background: #2a2a2a;
+    border-radius: 4px;
+  }
+  .gamepad-dpad-c {
+    position: absolute;
+    top: 29px; left: 29px;
+    width: 22px; height: 22px;
+    background: #1a1a1a;
+    border-radius: 3px;
+  }
+  .gamepad-dpad-zone {
+    position: absolute;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+  }
+  .gamepad-dpad-zone:active ~ .gamepad-dpad-h,
+  .gamepad-dpad-zone:active ~ .gamepad-dpad-v { background: #444; }
+  .gamepad-dpad-up { top: 0; left: 27px; width: 26px; height: 27px; }
+  .gamepad-dpad-down { bottom: 0; left: 27px; width: 26px; height: 27px; }
+  .gamepad-dpad-left { top: 27px; left: 0; width: 27px; height: 26px; }
+  .gamepad-dpad-right { top: 27px; right: 0; width: 27px; height: 26px; }
+  .gamepad-ab {
+    display: flex;
+    gap: 6px;
+    align-items: flex-end;
+  }
+  .gamepad-btn-b {
+    width: 40px; height: 40px;
+    border-radius: 20px;
+    background: #2a2a2a;
+    border: none;
+    cursor: pointer;
+  }
+  .gamepad-btn-b:active { background: #444; }
+  .gamepad-btn-a {
+    width: 44px; height: 44px;
+    border-radius: 22px;
+    background: #e8e8e8;
+    border: none;
+    cursor: pointer;
+  }
+  .gamepad-btn-a:active { background: #fff; }
 
   .editor-chat {
     flex: 1;
@@ -1375,9 +1473,32 @@
       </div>
       </div>
     </div>
-    <div class="editor-gamepad-toggle">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="6" width="20" height="12" rx="2"/><line x1="6" y1="12" x2="10" y2="12"/><line x1="8" y1="10" x2="8" y2="14"/><circle cx="15" cy="11" r="1"/><circle cx="18" cy="13" r="1"/></svg>
-      Show gamepad
+    <div class="gamepad-bar">
+      <span class="gamepad-bar-icon">✚ ·•</span>
+      <div class="gamepad-bar-btns">
+        <button class="gamepad-btn" id="gp-select" data-key="select">SELECT</button>
+        <button class="gamepad-btn" id="gp-start" data-key="start">START</button>
+      </div>
+      <button class="gamepad-expand" id="gp-expand">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+    </div>
+    <div class="gamepad-panel" id="gamepad-panel">
+      <div class="gamepad-controls">
+        <div class="gamepad-dpad" id="gp-dpad">
+          <div class="gamepad-dpad-h"></div>
+          <div class="gamepad-dpad-v"></div>
+          <div class="gamepad-dpad-c"></div>
+          <button class="gamepad-dpad-zone gamepad-dpad-up" data-key="up"></button>
+          <button class="gamepad-dpad-zone gamepad-dpad-down" data-key="down"></button>
+          <button class="gamepad-dpad-zone gamepad-dpad-left" data-key="left"></button>
+          <button class="gamepad-dpad-zone gamepad-dpad-right" data-key="right"></button>
+        </div>
+        <div class="gamepad-ab">
+          <button class="gamepad-btn-b" id="gp-b" data-key="b"></button>
+          <button class="gamepad-btn-a" id="gp-a" data-key="a"></button>
+        </div>
+      </div>
     </div>
     <div class="editor-chat" id="editor-chat">
       <div class="chat-msg">
@@ -2806,6 +2927,24 @@ function stopGame() {
     window._origConsoleError = null;
   }
 }
+
+// ── Gamepad ──
+document.getElementById("gp-expand").addEventListener("click", () => {
+  const panel = document.getElementById("gamepad-panel");
+  const btn = document.getElementById("gp-expand");
+  panel.classList.toggle("show");
+  btn.innerHTML = panel.classList.contains("show")
+    ? '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg>'
+    : '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>';
+});
+
+// Wire gamepad buttons to engine input
+document.querySelectorAll("[data-key]").forEach(btn => {
+  const key = btn.dataset.key;
+  btn.addEventListener("pointerdown", (e) => { e.preventDefault(); if (typeof Mono !== "undefined" && Mono.setKey) Mono.setKey(key, true); });
+  btn.addEventListener("pointerup", () => { if (typeof Mono !== "undefined" && Mono.setKey) Mono.setKey(key, false); });
+  btn.addEventListener("pointerleave", () => { if (typeof Mono !== "undefined" && Mono.setKey) Mono.setKey(key, false); });
+});
 
 // ── Screen Scale ──
 function buildScaleOptions() {

--- a/dev/index.html
+++ b/dev/index.html
@@ -2947,9 +2947,20 @@ document.getElementById("gp-expand").addEventListener("click", () => {
 // Wire gamepad buttons to engine input
 document.querySelectorAll("[data-key]").forEach(btn => {
   const key = btn.dataset.key;
-  btn.addEventListener("pointerdown", (e) => { e.preventDefault(); if (typeof Mono !== "undefined" && Mono.setKey) Mono.setKey(key, true); });
-  btn.addEventListener("pointerup", () => { if (typeof Mono !== "undefined" && Mono.setKey) Mono.setKey(key, false); });
-  btn.addEventListener("pointerleave", () => { if (typeof Mono !== "undefined" && Mono.setKey) Mono.setKey(key, false); });
+  btn.style.touchAction = "none"; // prevent browser gesture interference
+  btn.addEventListener("pointerdown", (e) => {
+    e.preventDefault();
+    console.log("[Gamepad]", key, "down");
+    if (typeof Mono !== "undefined" && Mono.setKey) Mono.setKey(key, true);
+  });
+  btn.addEventListener("pointerup", (e) => {
+    e.preventDefault();
+    console.log("[Gamepad]", key, "up");
+    if (typeof Mono !== "undefined" && Mono.setKey) Mono.setKey(key, false);
+  });
+  btn.addEventListener("pointerleave", () => {
+    if (typeof Mono !== "undefined" && Mono.setKey) Mono.setKey(key, false);
+  });
 });
 
 // ── Screen Scale ──

--- a/dev/index.html
+++ b/dev/index.html
@@ -2932,7 +2932,9 @@ function stopGame() {
 document.getElementById("gp-expand").addEventListener("click", () => {
   const panel = document.getElementById("gamepad-panel");
   const btn = document.getElementById("gp-expand");
+  const icon = document.querySelector(".gamepad-bar-icon");
   panel.classList.toggle("show");
+  icon.style.visibility = panel.classList.contains("show") ? "hidden" : "visible";
   btn.innerHTML = panel.classList.contains("show")
     ? '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg>'
     : '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>';


### PR DESCRIPTION
## Summary

- Collapsible gamepad bar: `✚ ·•` icon + SELECT/START (collapsed), D-pad + A/B (expanded)
- Cross-shaped D-pad matching console design (Dj4Kw reference)
- Diagonal A/B button layout (B bottom-left, A top-right)
- Buttons wired to `Mono.setKey()` via pointer events
- Icon hidden when panel expanded (visibility:hidden to preserve layout)
- Design updated in mono.pen

## Test plan

- [ ] Collapsed bar shows SELECT/START centered, icon left, expand right
- [ ] Expand toggle reveals D-pad + A/B panel
- [ ] Collapse hides panel and restores icon
- [ ] Gamepad buttons register in console log during game play
- [ ] A/B diagonal layout matches design

🤖 Generated with [Claude Code](https://claude.com/claude-code)