### PR TITLE
feat: motion sensor APIs + demo + headless test support

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -64,6 +64,7 @@
     <a href="/play.html?game=tiltmaze">tiltmaze <span class="tag">scene</span></a>
     <a href="/play.html?game=synth">synth <span class="tag">audio</span></a>
     <a href="/play.html?game=clock">clock <span class="tag">time</span></a>
+    <a href="/play.html?game=motion">motion <span class="tag">sensor</span></a>
     <a href="/play.html?game=engine-test">engine-test <span class="tag">api</span></a>
     <a href="/demo/scene-test/">scene-test</a>
     <a href="/demo/shader-test/">shader-test</a>

--- a/demo/motion/main.lua
+++ b/demo/motion/main.lua
@@ -9,6 +9,9 @@ end
 local ball_x, ball_y
 local trail = {}
 local MAX_TRAIL = 20
+local mx, my, mz = 0, 0, 0
+local ga, gb, gg = 0, 0, 0
+local enabled = false
 
 function _start()
   ball_x = SCREEN_W / 2
@@ -16,9 +19,16 @@ function _start()
 end
 
 function _update()
+  -- Read sensors once per frame
+  mx = motion_x()
+  my = motion_y()
+  mz = motion_z()
+  ga = gyro_alpha()
+  gb = gyro_beta()
+  gg = gyro_gamma()
+  enabled = motion_enabled() == 1
+
   -- Move ball with accelerometer tilt
-  local mx = motion_x()
-  local my = motion_y()
   ball_x = ball_x + mx * 3
   ball_y = ball_y + my * 3
 
@@ -51,26 +61,21 @@ function _draw()
   -- Ball
   circf(scr, math.floor(ball_x), math.floor(ball_y), 3, 15)
 
-  -- Data overlay
-  local mx = motion_x()
-  local my = motion_y()
-  local mz = motion_z()
+  -- Accelerometer
+  local col = enabled and 15 or 5
   text(scr, "MOTION", 2, 2, 8)
-  text(scr, "X:" .. string.format("%.2f", mx), 2, 12, motion_enabled() == 1 and 15 or 5)
-  text(scr, "Y:" .. string.format("%.2f", my), 2, 20, motion_enabled() == 1 and 15 or 5)
-  text(scr, "Z:" .. string.format("%.2f", mz), 2, 28, motion_enabled() == 1 and 15 or 5)
+  text(scr, "X:" .. string.format("%.2f", mx), 2, 12, col)
+  text(scr, "Y:" .. string.format("%.2f", my), 2, 20, col)
+  text(scr, "Z:" .. string.format("%.2f", mz), 2, 28, col)
 
   -- Gyroscope
-  local ga = gyro_alpha()
-  local gb = gyro_beta()
-  local gg = gyro_gamma()
   text(scr, "GYRO", 2, 40, 8)
   text(scr, "A:" .. math.floor(ga), 2, 50, 11)
   text(scr, "B:" .. math.floor(gb), 2, 58, 11)
   text(scr, "G:" .. math.floor(gg), 2, 66, 11)
 
   -- Status
-  if motion_enabled() == 0 then
+  if not enabled then
     text(scr, "TILT DEVICE", 0, SCREEN_H - 10, 5, ALIGN_HCENTER)
   end
 end

--- a/demo/motion/main.lua
+++ b/demo/motion/main.lua
@@ -1,0 +1,76 @@
+-- Motion Sensor Demo
+-- Tilt your device to move the ball. Shows accelerometer + gyroscope data.
+local scr = screen()
+
+function _init()
+  mode(4)
+end
+
+local ball_x, ball_y
+local trail = {}
+local MAX_TRAIL = 20
+
+function _start()
+  ball_x = SCREEN_W / 2
+  ball_y = SCREEN_H / 2
+end
+
+function _update()
+  -- Move ball with accelerometer tilt
+  local mx = motion_x()
+  local my = motion_y()
+  ball_x = ball_x + mx * 3
+  ball_y = ball_y + my * 3
+
+  -- Clamp to screen
+  if ball_x < 4 then ball_x = 4 end
+  if ball_x > SCREEN_W - 4 then ball_x = SCREEN_W - 4 end
+  if ball_y < 4 then ball_y = 4 end
+  if ball_y > SCREEN_H - 4 then ball_y = SCREEN_H - 4 end
+
+  -- Trail
+  table.insert(trail, 1, { x = ball_x, y = ball_y })
+  if #trail > MAX_TRAIL then table.remove(trail) end
+end
+
+function _draw()
+  cls(scr, 0)
+
+  -- Crosshair at center
+  local cx, cy = SCREEN_W / 2, SCREEN_H / 2
+  line(scr, cx - 10, cy, cx + 10, cy, 2)
+  line(scr, cx, cy - 10, cx, cy + 10, 2)
+
+  -- Trail (fading)
+  for i = #trail, 1, -1 do
+    local t = trail[i]
+    local c = math.max(1, math.floor(15 - (i - 1) * 15 / MAX_TRAIL))
+    circf(scr, math.floor(t.x), math.floor(t.y), 2, c)
+  end
+
+  -- Ball
+  circf(scr, math.floor(ball_x), math.floor(ball_y), 3, 15)
+
+  -- Data overlay
+  local mx = motion_x()
+  local my = motion_y()
+  local mz = motion_z()
+  text(scr, "MOTION", 2, 2, 8)
+  text(scr, "X:" .. string.format("%.2f", mx), 2, 12, motion_enabled() == 1 and 15 or 5)
+  text(scr, "Y:" .. string.format("%.2f", my), 2, 20, motion_enabled() == 1 and 15 or 5)
+  text(scr, "Z:" .. string.format("%.2f", mz), 2, 28, motion_enabled() == 1 and 15 or 5)
+
+  -- Gyroscope
+  local ga = gyro_alpha()
+  local gb = gyro_beta()
+  local gg = gyro_gamma()
+  text(scr, "GYRO", 2, 40, 8)
+  text(scr, "A:" .. math.floor(ga), 2, 50, 11)
+  text(scr, "B:" .. math.floor(gb), 2, 58, 11)
+  text(scr, "G:" .. math.floor(gg), 2, 66, 11)
+
+  -- Status
+  if motion_enabled() == 0 then
+    text(scr, "TILT DEVICE", 0, SCREEN_H - 10, 5, ALIGN_HCENTER)
+  end
+end

--- a/editor/templates/mono/mono-test.js
+++ b/editor/templates/mono/mono-test.js
@@ -740,6 +740,14 @@ async function main() {
   lua.global.set("cam_reset", () => {});
   lua.global.set("axis_x", () => 0);
   lua.global.set("axis_y", () => 0);
+  // Motion sensor stubs (headless = no motion)
+  lua.global.set("motion_x", () => 0);
+  lua.global.set("motion_y", () => 0);
+  lua.global.set("motion_z", () => 0);
+  lua.global.set("gyro_alpha", () => 0);
+  lua.global.set("gyro_beta", () => 0);
+  lua.global.set("gyro_gamma", () => 0);
+  lua.global.set("motion_enabled", () => 0);
   lua.global.set("spr", (id, imgId, x, y) => { const s = requireSurf("spr", id); drawImageFn(s, imgId, x, y); });
   lua.global.set("sspr", (id, imgId, sx, sy, sw, sh, dx, dy) => { const s = requireSurf("sspr", id); drawImageRegionFn(s, imgId, sx, sy, sw, sh, dx, dy); });
   lua.global.set("drawImage", (id, imgId, x, y) => { const s = requireSurf("drawImage", id); drawImageFn(s, imgId, x, y); });

--- a/editor/templates/mono/mono-test.js
+++ b/editor/templates/mono/mono-test.js
@@ -19,6 +19,7 @@
  *   --touch "F:A:X,Y" Inject touch events inline or from file
  *                     Inline: "5:start:80,60;7:end:80,60"
  *                     File:   touch-events.txt (one event per line, # comments)
+ *   --motion "F:X,Y,Z" Inject motion values at frame F (e.g., "5:0.5,0.3,0;10:-0.2,0,0")
  *   --snapshot FILE  Save vdump to file
  *   --diff FILE      Compare vdump against expected file
  *   --replay FILE    Load input sequence from file and replay
@@ -56,6 +57,7 @@ Options:
   --suite          Test suite mode (parse PASS/FAIL)
   --input "F:K"    Inject input (e.g., "3:a,5:up")
   --touch "F:A:X,Y" Inject touch inline or from file
+  --motion "F:X,Y,Z" Inject motion values (e.g., "5:0.5,0.3,0;10:-0.2,0,0")
   --snapshot FILE  Save vdump to file
   --diff FILE      Compare vdump against expected file
   --replay FILE    Load input sequence from file and replay
@@ -124,6 +126,7 @@ const goldenFile = getOpt("golden", null);
 const goldenUpdate = hasFlag("golden-update");
 const benchMode = hasFlag("bench");
 const fuzzRuns = parseInt(getOpt("fuzz", "0")) || 0;
+const motionArg = getOpt("motion", null);
 const scanDir = getOpt("scan", null);
 let runSeed = null;
 
@@ -487,6 +490,31 @@ function drawImageRegionFn(s, id, sx, sy, sw, sh, dx, dy) {
   }
 }
 
+// --- Motion simulation ---
+let simMotionX = 0, simMotionY = 0, simMotionZ = 0;
+let simMotionEnabled = false;
+const motionSchedule = {};
+
+if (motionArg) {
+  // Parse "5:0.5,0.3,0" → { 5: { x:0.5, y:0.3, z:0 } }
+  for (const part of motionArg.split(";")) {
+    const [f, vals] = part.trim().split(":");
+    const frame = parseInt(f);
+    const [x, y, z] = (vals || "0,0,0").split(",").map(Number);
+    motionSchedule[frame] = { x: x || 0, y: y || 0, z: z || 0 };
+  }
+  simMotionEnabled = true;
+}
+
+function applyMotion(frame) {
+  if (motionSchedule[frame]) {
+    const m = motionSchedule[frame];
+    simMotionX = Math.max(-1, Math.min(1, m.x));
+    simMotionY = Math.max(-1, Math.min(1, m.y));
+    simMotionZ = Math.max(-1, Math.min(1, m.z));
+  }
+}
+
 // --- Input simulation ---
 const keys = {};
 const keysPrev = {};
@@ -740,14 +768,14 @@ async function main() {
   lua.global.set("cam_reset", () => {});
   lua.global.set("axis_x", () => 0);
   lua.global.set("axis_y", () => 0);
-  // Motion sensor stubs (headless = no motion)
-  lua.global.set("motion_x", () => 0);
-  lua.global.set("motion_y", () => 0);
-  lua.global.set("motion_z", () => 0);
+  // Motion sensor (simulated via --motion or --fuzz)
+  lua.global.set("motion_x", () => simMotionX);
+  lua.global.set("motion_y", () => simMotionY);
+  lua.global.set("motion_z", () => simMotionZ);
   lua.global.set("gyro_alpha", () => 0);
   lua.global.set("gyro_beta", () => 0);
   lua.global.set("gyro_gamma", () => 0);
-  lua.global.set("motion_enabled", () => 0);
+  lua.global.set("motion_enabled", () => simMotionEnabled ? 1 : 0);
   lua.global.set("spr", (id, imgId, x, y) => { const s = requireSurf("spr", id); drawImageFn(s, imgId, x, y); });
   lua.global.set("sspr", (id, imgId, sx, sy, sw, sh, dx, dy) => { const s = requireSurf("sspr", id); drawImageRegionFn(s, imgId, sx, sy, sw, sh, dx, dy); });
   lua.global.set("drawImage", (id, imgId, x, y) => { const s = requireSurf("drawImage", id); drawImageFn(s, imgId, x, y); });
@@ -1100,6 +1128,7 @@ end
   for (let f = 1; f <= frameCount; f++) {
     applyInput(f);
     applyTouch(f);
+    applyMotion(f);
 
     // Bot: call _bot() after draw, inject result as input for next frame
     if (botFn && f > 1) {
@@ -1755,6 +1784,20 @@ if (totalRuns > 1) {
         const key = validKeys[Math.floor(rng() * validKeys.length)];
         if (!inputSchedule[frame]) inputSchedule[frame] = [];
         inputSchedule[frame].push(key);
+      }
+
+      // Random motion events for fuzz
+      for (const k of Object.keys(motionSchedule)) delete motionSchedule[k];
+      simMotionX = 0; simMotionY = 0; simMotionZ = 0;
+      simMotionEnabled = true;
+      const numMotion = 1 + Math.floor(rng() * 10);
+      for (let i = 0; i < numMotion; i++) {
+        const frame = 1 + Math.floor(rng() * Math.max(1, frameCount));
+        motionSchedule[frame] = {
+          x: (rng() * 2 - 1),  // -1 to 1
+          y: (rng() * 2 - 1),
+          z: (rng() * 2 - 1),
+        };
       }
 
       // Suppress verbose output during fuzz runs

--- a/editor/templates/mono/mono-test.js
+++ b/editor/templates/mono/mono-test.js
@@ -512,6 +512,7 @@ function applyMotion(frame) {
     simMotionX = Math.max(-1, Math.min(1, m.x));
     simMotionY = Math.max(-1, Math.min(1, m.y));
     simMotionZ = Math.max(-1, Math.min(1, m.z));
+    simMotionEnabled = true; // activate on first injection
   }
 }
 
@@ -1786,10 +1787,10 @@ if (totalRuns > 1) {
         inputSchedule[frame].push(key);
       }
 
-      // Random motion events for fuzz
+      // Random motion events for fuzz (motion_enabled stays false unless game reads it)
       for (const k of Object.keys(motionSchedule)) delete motionSchedule[k];
       simMotionX = 0; simMotionY = 0; simMotionZ = 0;
-      simMotionEnabled = true;
+      simMotionEnabled = false;
       const numMotion = 1 + Math.floor(rng() * 10);
       for (let i = 0; i < numMotion; i++) {
         const frame = 1 + Math.floor(rng() * Math.max(1, frameCount));

--- a/play.html
+++ b/play.html
@@ -114,7 +114,8 @@
     tiltmaze:    { path: "/demo/tiltmaze/main.lua",    colors: 4 },
     synth:       { path: "/demo/synth/main.lua",       colors: 4 },
     clock:       { path: "/demo/clock/main.lua",       colors: 4 },
-    "engine-test": { path: "/demo/engine-test/main.lua", colors: 4 }
+    "engine-test": { path: "/demo/engine-test/main.lua", colors: 4 },
+    motion:      { path: "/demo/motion/main.lua",      colors: 4 }
   };
 
   var params = new URLSearchParams(location.search);

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -499,6 +499,26 @@ var Mono = (() => {
   let axisX = 0, axisY = 0;
   let axisSource = "none"; // "keyboard" | "gamepad" | "none"
 
+  // --- Motion sensor (accelerometer/gyroscope) ---
+  let motionX = 0, motionY = 0, motionZ = 0; // accelerometer (-1 to 1, normalized)
+  let gyroAlpha = 0, gyroBeta = 0, gyroGamma = 0; // gyroscope (degrees)
+  let motionEnabled = false;
+  if (typeof window !== "undefined" && window.DeviceMotionEvent) {
+    window.addEventListener("devicemotion", (e) => {
+      const a = e.accelerationIncludingGravity;
+      if (!a) return;
+      motionEnabled = true;
+      motionX = Math.max(-1, Math.min(1, (a.x || 0) / 9.8));
+      motionY = Math.max(-1, Math.min(1, (a.y || 0) / 9.8));
+      motionZ = Math.max(-1, Math.min(1, (a.z || 0) / 9.8));
+    });
+    window.addEventListener("deviceorientation", (e) => {
+      gyroAlpha = e.alpha || 0;
+      gyroBeta = e.beta || 0;
+      gyroGamma = e.gamma || 0;
+    });
+  }
+
   // --- Touch / Mouse ---
   let touches = [];           // [{ id, x, y, fx, fy }]
   let touchStartedFlag = false;
@@ -862,6 +882,14 @@ var Mono = (() => {
     });
     lua.global.set("axis_x", () => axisX);
     lua.global.set("axis_y", () => axisY);
+    // Motion sensor APIs (accelerometer + gyroscope)
+    lua.global.set("motion_x", () => motionX);     // -1 to 1 (tilt left/right)
+    lua.global.set("motion_y", () => motionY);     // -1 to 1 (tilt forward/back)
+    lua.global.set("motion_z", () => motionZ);     // -1 to 1 (face up/down)
+    lua.global.set("gyro_alpha", () => gyroAlpha); // 0-360 compass heading
+    lua.global.set("gyro_beta", () => gyroBeta);   // -180 to 180 front/back tilt
+    lua.global.set("gyro_gamma", () => gyroGamma); // -90 to 90 left/right tilt
+    lua.global.set("motion_enabled", () => motionEnabled ? 1 : 0);
     // Check both latched state and raw flag: inputUpdate() runs after _update(),
     // so a fast click (mousedown+mouseup between frames) would be missed without the flag check.
     lua.global.set("_touch", () => touches.length > 0 || touchStartedFlag ? 1 : 0);

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -508,7 +508,7 @@ var Mono = (() => {
       const a = e.accelerationIncludingGravity;
       if (!a) return;
       motionEnabled = true;
-      motionX = Math.max(-1, Math.min(1, -(a.x || 0) / 9.8)); // negated: tilt right = positive
+      motionX = Math.max(-1, Math.min(1, (a.x || 0) / 9.8)); // W3C spec: tilt right = positive x
       motionY = Math.max(-1, Math.min(1, (a.y || 0) / 9.8));
       motionZ = Math.max(-1, Math.min(1, (a.z || 0) / 9.8));
     });

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -508,7 +508,7 @@ var Mono = (() => {
       const a = e.accelerationIncludingGravity;
       if (!a) return;
       motionEnabled = true;
-      motionX = Math.max(-1, Math.min(1, (a.x || 0) / 9.8));
+      motionX = Math.max(-1, Math.min(1, -(a.x || 0) / 9.8)); // negated: tilt right = positive
       motionY = Math.max(-1, Math.min(1, (a.y || 0) / 9.8));
       motionZ = Math.max(-1, Math.min(1, (a.z || 0) / 9.8));
     });


### PR DESCRIPTION
## Summary

- **Engine**: `motion_x/y/z()`, `gyro_alpha/beta/gamma()`, `motion_enabled()` APIs
- **Demo**: `demo/motion/` — tilt ball with trail, accelerometer + gyroscope data overlay
- **Headless test**: `--motion "F:X,Y,Z"` injection, `--fuzz` includes random motion
- **Fix**: Removed incorrect motion_x inversion (W3C spec: tilt right = already positive)

## API

| Function | Returns | Description |
|----------|---------|-------------|
| `motion_x()` | -1 to 1 | Tilt left/right |
| `motion_y()` | -1 to 1 | Tilt forward/back |
| `motion_z()` | -1 to 1 | Face up/down |
| `gyro_alpha()` | 0-360 | Compass heading |
| `gyro_beta()` | -180 to 180 | Front/back tilt |
| `gyro_gamma()` | -90 to 90 | Left/right tilt |
| `motion_enabled()` | 0 or 1 | Device supports motion |

## Test plan

- [ ] `demo/motion` — tilt device, ball moves, data displays
- [ ] `--motion "1:0.8,0,0;10:0,0,0"` — headless injection works
- [ ] `--fuzz 10` on motion demo — no crashes
- [ ] `motion_enabled()` = 0 by default, 1 after injection
- [ ] Existing demos unaffected

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)