### PR TITLE
feat: publish system

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -3407,7 +3407,9 @@ async function publishGame() {
         headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/octet-stream" },
         body: blob,
       });
-    } catch {}
+    } catch (e) {
+      console.warn("Thumbnail generation failed:", e);
+    }
   }
 
   // 4. Call publish API

--- a/dev/index.html
+++ b/dev/index.html
@@ -3504,6 +3504,31 @@ function syncLog(msg, files) {
   chat.scrollTop = chat.scrollHeight;
 }
 
+// Recursively read all files from a directory handle
+async function readDirRecursive(dirHandle, prefix = "") {
+  const entries = [];
+  for await (const [name, handle] of dirHandle) {
+    if (name.startsWith("_") || name.startsWith(".")) continue;
+    const path = prefix ? prefix + "/" + name : name;
+    if (handle.kind === "file") {
+      entries.push({ path, handle, dirHandle });
+    } else if (handle.kind === "directory") {
+      entries.push(...await readDirRecursive(handle, path));
+    }
+  }
+  return entries;
+}
+
+// Get or create a file handle for a path with subdirectories
+async function getFileHandleDeep(rootHandle, path, create = false) {
+  const parts = path.split("/");
+  let dir = rootHandle;
+  for (let i = 0; i < parts.length - 1; i++) {
+    dir = await dir.getDirectoryHandle(parts[i], { create });
+  }
+  return await dir.getFileHandle(parts[parts.length - 1], { create });
+}
+
 async function deleteR2File(name) {
   const token = await auth.currentUser.getIdToken();
   await fetch(`${API_URL}/games/${currentGameId}/files/${name}`, {
@@ -3533,15 +3558,13 @@ document.getElementById("btn-sync-push").addEventListener("click", async () => {
   try {
     const gameFiles = currentFiles.filter(f => !f.name.startsWith("_"));
 
-    // Collect local file names for delete detection
-    const localNames = new Set();
-    for await (const [name, handle] of linkedDirHandle) {
-      if (handle.kind === "file" && !name.startsWith("_") && !name.startsWith(".")) localNames.add(name);
-    }
+    // Collect local file paths (recursive) for delete detection
+    const localEntries = await readDirRecursive(linkedDirHandle);
+    const localNames = new Set(localEntries.map(e => e.path));
 
-    // Write all game files in parallel
+    // Write all game files in parallel (create subdirs as needed)
     await Promise.all(gameFiles.map(async (f) => {
-      const fh = await linkedDirHandle.getFileHandle(f.name, { create: true });
+      const fh = await getFileHandleDeep(linkedDirHandle, f.name, true);
       const w = await fh.createWritable();
       await w.write(f.content);
       await w.close();
@@ -3553,9 +3576,12 @@ document.getElementById("btn-sync-push").addEventListener("click", async () => {
     let deleted = [];
     if (orphanLocal.length > 0) {
       if (confirm(`These local files are not in the cloud and will be deleted:\n\n${orphanLocal.join("\n")}\n\nDelete them?`)) {
-        await Promise.all(orphanLocal.map(async (name) => {
-          await linkedDirHandle.removeEntry(name);
-        }));
+        for (const path of orphanLocal) {
+          const parts = path.split("/");
+          let dir = linkedDirHandle;
+          for (let i = 0; i < parts.length - 1; i++) dir = await dir.getDirectoryHandle(parts[i]);
+          await dir.removeEntry(parts[parts.length - 1]);
+        }
         deleted = orphanLocal;
       }
     }
@@ -3576,13 +3602,13 @@ document.getElementById("btn-sync-pull").addEventListener("click", async () => {
   const btn = document.getElementById("btn-sync-pull");
   syncBusy = true; btn.disabled = true; btn.textContent = "Pulling…";
   try {
-    // Read all local files
+    // Read all local files (recursive)
     const localFiles = [];
-    for await (const [name, handle] of linkedDirHandle) {
-      if (handle.kind !== "file" || name.startsWith("_") || name.startsWith(".")) continue;
-      const file = await handle.getFile();
+    const entries = await readDirRecursive(linkedDirHandle);
+    for (const entry of entries) {
+      const file = await entry.handle.getFile();
       const content = await file.text();
-      localFiles.push({ name, content });
+      localFiles.push({ name: entry.path, content });
     }
 
     // Update currentFiles + save to R2 in parallel

--- a/dev/index.html
+++ b/dev/index.html
@@ -3385,7 +3385,32 @@ async function publishGame() {
 
   btn.textContent = "Publishing...";
 
-  // 3. Call publish API
+  // 3. Generate thumbnail from test screen buffer
+  if (result.screen) {
+    try {
+      const { buf, w, h, palette } = result.screen;
+      const c = new OffscreenCanvas(w, h);
+      const ctx = c.getContext("2d");
+      const img = ctx.createImageData(w, h);
+      for (let i = 0; i < buf.length; i++) {
+        const v = palette[buf[i]] ?? 0;
+        img.data[i * 4] = v;
+        img.data[i * 4 + 1] = v;
+        img.data[i * 4 + 2] = v;
+        img.data[i * 4 + 3] = 255;
+      }
+      ctx.putImageData(img, 0, 0);
+      const blob = await c.convertToBlob({ type: "image/png" });
+      const token = await auth.currentUser.getIdToken();
+      await fetch(`${API_URL}/games/${currentGameId}/files/thumbnail.png`, {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/octet-stream" },
+        body: blob,
+      });
+    } catch {}
+  }
+
+  // 4. Call publish API
   try {
     const token = await auth.currentUser.getIdToken();
     const res = await fetch(`${API_URL}/games/${currentGameId}/publish`, {

--- a/dev/index.html
+++ b/dev/index.html
@@ -1342,6 +1342,56 @@
     color: #888;
     line-height: 1.5;
   }
+
+  /* ── Publish ── */
+  .publish-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+  .publish-badge {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    padding: 3px 8px;
+    border-radius: 4px;
+  }
+  .publish-badge.draft {
+    background: #2a2a2a;
+    color: #888;
+  }
+  .publish-badge.published {
+    background: #1a2e1a;
+    color: #6c6;
+  }
+  .publish-version {
+    font-size: 11px;
+    color: #555;
+  }
+  .settings-publish-btn {
+    width: 100%;
+    height: 40px;
+    background: #eee;
+    color: #111;
+    border: none;
+    border-radius: 8px;
+    font-family: 'Inter', sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    margin-top: 8px;
+  }
+  .settings-publish-btn:hover { background: #fff; }
+  .settings-publish-btn:disabled { background: #555; color: #888; cursor: not-allowed; }
+  .settings-publish-btn.unpublish {
+    background: transparent;
+    border: 1px solid #333;
+    color: #888;
+  }
+  .settings-publish-btn.unpublish:hover { border-color: #555; color: #ccc; }
+
   .btn-delete-game {
     width: 100%;
     height: 48px;
@@ -1736,6 +1786,17 @@
           <textarea class="settings-card-input settings-card-textarea" id="settings-desc" maxlength="120"></textarea>
         </div>
         <button class="settings-save-btn" id="btn-save-info">Save</button>
+      </div>
+      <div class="settings-section">
+        <span class="settings-section-label">Publish</span>
+        <div class="settings-card">
+          <div class="publish-status" id="publish-status">
+            <span class="publish-badge draft" id="publish-badge">Draft</span>
+            <span class="publish-version" id="publish-version"></span>
+          </div>
+          <p class="settings-danger-text" id="publish-desc">Publish this game to make it publicly playable. A snapshot of the current files will be saved.</p>
+          <button class="settings-publish-btn" id="btn-publish">Publish</button>
+        </div>
       </div>
       <div class="settings-section">
         <span class="settings-section-label danger">Danger Zone</span>
@@ -2482,10 +2543,22 @@ async function openEditor(gameId, title, desc) {
   currentGameId = gameId;
   currentGameTitle = title;
   currentGameDesc = desc || "";
+  currentGameStatus = "draft";
+  currentPublishedVersion = 0;
   chatHistory.length = 0;
   currentFiles = [];
   sessionTokens = { prompt: 0, completion: 0, total: 0 };
   document.getElementById("editor-usage").textContent = "";
+
+  // Load game status from Firestore
+  try {
+    const gameSnap = await getDoc(doc(db, "games", gameId));
+    if (gameSnap.exists()) {
+      const gd = gameSnap.data();
+      currentGameStatus = gd.status || "draft";
+      currentPublishedVersion = gd.publishedVersion || 0;
+    }
+  } catch {}
 
   // Load AI providers if not loaded yet
   if (aiProviders.length === 0 && localStorage.getItem("mono_vault_pp")) {
@@ -3182,10 +3255,13 @@ document.getElementById("btn-run").addEventListener("click", () => {
 // ── Game Settings ──
 let currentGameTitle = "";
 let currentGameDesc = "";
+let currentGameStatus = "draft";
+let currentPublishedVersion = 0;
 
 document.getElementById("btn-game-settings").addEventListener("click", () => {
   document.getElementById("settings-title").value = currentGameTitle;
   document.getElementById("settings-desc").value = currentGameDesc || "";
+  updatePublishUI();
   showView("game-settings");
 });
 
@@ -3250,6 +3326,112 @@ document.getElementById("btn-delete-game").addEventListener("click", async () =>
     alert("Failed to delete: " + e.message);
   }
 });
+
+// ── Publish ──
+function updatePublishUI() {
+  const badge = document.getElementById("publish-badge");
+  const version = document.getElementById("publish-version");
+  const desc = document.getElementById("publish-desc");
+  const btn = document.getElementById("btn-publish");
+
+  if (currentGameStatus === "published") {
+    badge.className = "publish-badge published";
+    badge.textContent = "Published";
+    version.textContent = currentPublishedVersion ? `v${currentPublishedVersion}` : "";
+    desc.textContent = "This game is live. You can unpublish to take it offline, or publish again to update.";
+    btn.textContent = "Unpublish";
+    btn.className = "settings-publish-btn unpublish";
+  } else {
+    badge.className = "publish-badge draft";
+    badge.textContent = "Draft";
+    version.textContent = "";
+    desc.textContent = "Publish this game to make it publicly playable. A snapshot of the current files will be saved.";
+    btn.textContent = "Publish";
+    btn.className = "settings-publish-btn";
+  }
+  btn.disabled = false;
+}
+
+document.getElementById("btn-publish").addEventListener("click", async () => {
+  if (currentGameStatus === "published") {
+    await unpublishGame();
+  } else {
+    await publishGame();
+  }
+});
+
+async function publishGame() {
+  const btn = document.getElementById("btn-publish");
+
+  // 1. Check main.lua exists
+  const mainFile = currentFiles.find(f => f.name === "main.lua");
+  if (!mainFile) {
+    alert("Cannot publish: main.lua is required.");
+    return;
+  }
+
+  btn.disabled = true;
+  btn.textContent = "Testing...";
+
+  // 2. Run headless test
+  const result = await runHeadlessTest(currentFiles, 30);
+  if (!result.success) {
+    const errors = (result.errors || []).join("\n");
+    alert("Cannot publish: test failed.\n\n" + errors);
+    btn.disabled = false;
+    btn.textContent = "Publish";
+    return;
+  }
+
+  btn.textContent = "Publishing...";
+
+  // 3. Call publish API
+  try {
+    const token = await auth.currentUser.getIdToken();
+    const res = await fetch(`${API_URL}/games/${currentGameId}/publish`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || `Publish failed (${res.status})`);
+    }
+    const data = await res.json();
+    currentGameStatus = "published";
+    currentPublishedVersion = data.version || (currentPublishedVersion + 1);
+    updatePublishUI();
+  } catch (e) {
+    alert("Publish failed: " + e.message);
+    btn.disabled = false;
+    btn.textContent = "Publish";
+  }
+}
+
+async function unpublishGame() {
+  if (!confirm("Unpublish this game? It will no longer be publicly playable.")) return;
+
+  const btn = document.getElementById("btn-publish");
+  btn.disabled = true;
+  btn.textContent = "Unpublishing...";
+
+  try {
+    const token = await auth.currentUser.getIdToken();
+    const res = await fetch(`${API_URL}/games/${currentGameId}/unpublish`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || `Unpublish failed (${res.status})`);
+    }
+    currentGameStatus = "draft";
+    updatePublishUI();
+  } catch (e) {
+    alert("Unpublish failed: " + e.message);
+    btn.disabled = false;
+    btn.textContent = "Unpublish";
+  }
+}
 
 // ── Editor AI shortcut ──
 document.getElementById("btn-editor-aip").addEventListener("click", openAIProviders);

--- a/dev/test-worker.js
+++ b/dev/test-worker.js
@@ -240,7 +240,12 @@ onmessage = async (e) => {
     }
 
     lua.global.close();
-    postMessage({ success: true, frames: frameNum, errors: [], output });
+
+    // Return screen buffer for thumbnail generation
+    const screenBuf = surfaces[0]?.buf;
+    const screenData = screenBuf ? { buf: Array.from(screenBuf), w: W, h: H, palette } : null;
+
+    postMessage({ success: true, frames: frameNum, errors: [], output, screen: screenData });
   } catch (e) {
     errors.push(e.message || String(e));
     postMessage({ success: false, errors, output });

--- a/index.html
+++ b/index.html
@@ -3,36 +3,255 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Mono</title>
+<title>Mono — Games</title>
 <link rel="icon" href="/favicon.png" type="image/png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
-    background: #1a1a1a;
-    color: #e8e8e8;
-    font-family: monospace;
+    background: #111;
+    color: #eee;
+    font-family: 'Inter', sans-serif;
+    min-height: 100vh;
+  }
+
+  /* ── Header ── */
+  .header {
     display: flex;
-    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 24px;
+    border-bottom: 1px solid #222;
+    position: sticky;
+    top: 0;
+    background: #111;
+    z-index: 10;
+  }
+  .header-logo {
+    font-size: 20px;
+    font-weight: 800;
+    letter-spacing: 3px;
+    color: #eee;
+    text-decoration: none;
+  }
+  .header-nav {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+  }
+  .header-nav a {
+    font-size: 13px;
+    color: #888;
+    text-decoration: none;
+    font-weight: 500;
+  }
+  .header-nav a:hover { color: #eee; }
+
+  /* ── Main content ── */
+  .main {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 32px 24px 64px;
+  }
+
+  /* ── Section ── */
+  .section-title {
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 16px;
+  }
+
+  /* ── Game Grid ── */
+  .game-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+  @media (max-width: 640px) {
+    .game-grid {
+      grid-template-columns: repeat(2, 1fr);
+      gap: 12px;
+    }
+  }
+
+  /* ── Game Card ── */
+  .game-card {
+    background: #1a1a1a;
+    border-radius: 12px;
+    overflow: hidden;
+    cursor: pointer;
+    transition: transform 0.15s, box-shadow 0.15s;
+  }
+  .game-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+  }
+  .game-thumb {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    background: #222;
+    display: flex;
     align-items: center;
     justify-content: center;
-    height: 100vh;
-    gap: 12px;
+    overflow: hidden;
   }
-  a {
-    color: #e8e8e8;
-    text-decoration: none;
-    border: 1px solid #6b6b6b;
-    padding: 12px 24px;
+  .game-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    image-rendering: pixelated;
+  }
+  .game-thumb-placeholder {
+    font-size: 32px;
+    color: #333;
+    font-weight: 800;
+    letter-spacing: 2px;
+    user-select: none;
+  }
+  .game-info {
+    padding: 10px 12px;
+  }
+  .game-title {
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .game-meta {
+    font-size: 11px;
+    color: #666;
+    margin-top: 2px;
+  }
+
+  /* ── Loading / Empty ── */
+  .loading, .empty {
+    text-align: center;
+    padding: 64px 0;
+    color: #555;
     font-size: 14px;
   }
-  a:hover { border-color: #e8e8e8; }
+  .loading::after {
+    content: '';
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 2px solid #333;
+    border-top-color: #888;
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+    margin-left: 8px;
+    vertical-align: middle;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* ── Footer ── */
+  .footer {
+    text-align: center;
+    padding: 32px;
+    color: #333;
+    font-size: 11px;
+    border-top: 1px solid #1a1a1a;
+  }
+  .footer a { color: #555; text-decoration: none; }
+  .footer a:hover { color: #888; }
 </style>
 </head>
 <body>
-  <a href="/engine-test/">engine-test</a>
-  <a href="/demo/">demo</a>
-  <a href="/playground/">playground</a>
-  <a href="/editor/">editor</a>
-  <a href="/tools/">tools</a>
+
+<div class="header">
+  <a href="/" class="header-logo">MONO</a>
+  <div class="header-nav">
+    <a href="/demo/">Demos</a>
+    <a href="/dev/">Developer</a>
+  </div>
+</div>
+
+<div class="main">
+  <h2 class="section-title">Games</h2>
+  <div id="game-grid" class="game-grid">
+    <div class="loading" id="loading">Loading</div>
+  </div>
+  <div class="empty" id="empty" style="display:none">No published games yet.</div>
+</div>
+
+<div class="footer">
+  <a href="/">MONO</a> — constraint-driven fantasy console
+</div>
+
+<script type="module">
+import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.1/firebase-app.js";
+import {
+  getFirestore,
+  collection,
+  query,
+  where,
+  orderBy,
+  getDocs
+} from "https://www.gstatic.com/firebasejs/11.7.1/firebase-firestore.js";
+
+const app = initializeApp({
+  apiKey: "AIzaSyAyTiJx_JkVdQoh8b5bDo-ttvp175vy8PM",
+  authDomain: "mono-5b951.firebaseapp.com",
+  projectId: "mono-5b951",
+  storageBucket: "mono-5b951.firebasestorage.app",
+  messagingSenderId: "850069827366",
+  appId: "1:850069827366:web:a196c04bbf4c93bd061be7"
+});
+const db = getFirestore(app);
+
+const API_URL = "https://api.monogame.cc";
+const grid = document.getElementById("game-grid");
+const loading = document.getElementById("loading");
+const empty = document.getElementById("empty");
+
+async function loadGames() {
+  try {
+    const q = query(
+      collection(db, "games"),
+      where("status", "==", "published"),
+      orderBy("publishedAt", "desc")
+    );
+    const snap = await getDocs(q);
+
+    loading.style.display = "none";
+
+    if (snap.empty) {
+      empty.style.display = "block";
+      return;
+    }
+
+    grid.innerHTML = snap.docs.map(doc => {
+      const g = doc.data();
+      const id = doc.id;
+      const title = esc(g.title || "Untitled");
+      const plays = g.plays || 0;
+      const thumbUrl = `${API_URL}/games/${id}/thumbnail`;
+      return `<div class="game-card" onclick="location.href='/play.html?id=${id}'">
+        <div class="game-thumb">
+          <img src="${thumbUrl}" alt="${title}" onerror="this.replaceWith(Object.assign(document.createElement('span'),{className:'game-thumb-placeholder',textContent:'M'}))">
+        </div>
+        <div class="game-info">
+          <div class="game-title">${title}</div>
+          <div class="game-meta">${plays} plays</div>
+        </div>
+      </div>`;
+    }).join("");
+  } catch (e) {
+    loading.style.display = "none";
+    grid.innerHTML = `<div class="empty">Failed to load games.</div>`;
+    console.error("Failed to load games:", e);
+  }
+}
+
+function esc(s) {
+  const d = document.createElement("div");
+  d.textContent = s;
+  return d.innerHTML.replace(/"/g, "&quot;");
+}
+
+loadGames();
+</script>
 </body>
 </html>

--- a/play.html
+++ b/play.html
@@ -144,7 +144,12 @@
           }
         }
         if (!mainSrc) throw new Error("No main.lua in published files");
-        await Mono.boot("screen", { source: mainSrc, modules: modules, colors: 4 });
+        await Mono.boot("screen", {
+          source: mainSrc,
+          modules: modules,
+          colors: 4,
+          readFile: function(name) { return modules[name] || null; },
+        });
         if (Mono.shader && Mono.shader.preset) Mono.shader.preset();
       } catch(e) {
         console.error("Boot failed:", e);

--- a/play.html
+++ b/play.html
@@ -118,15 +118,40 @@
     motion:      { path: "/demo/motion/main.lua",      colors: 4 }
   };
 
+  var API_URL = "https://api.monogame.cc";
   var params = new URLSearchParams(location.search);
   var gameName = params.get("game");
+  var gameId = params.get("id");
   var entry = gameName && GAMES[gameName];
 
-  if (!entry) {
+  if (gameId) {
+    // Published game: load files from R2
+    (async function() {
+      try {
+        var res = await fetch(API_URL + "/games/" + gameId + "/published");
+        if (!res.ok) throw new Error("Game not found");
+        var data = await res.json();
+        document.title = "Mono \u2014 " + (data.title || "Game");
+        document.getElementById("back-btn").href = "/";
+
+        var files = {};
+        for (var f of data.files) {
+          files[f.name] = f.content;
+        }
+        await Mono.boot("screen", { files: files, colors: 4 });
+        if (Mono.shader && Mono.shader.preset) Mono.shader.preset();
+      } catch(e) {
+        console.error("Boot failed:", e);
+        document.getElementById("error").style.display = "block";
+        document.getElementById("error").textContent = "Failed to load game: " + e.message;
+        document.getElementById("console").style.display = "none";
+      }
+    })();
+  } else if (!entry) {
     document.getElementById("error").style.display = "block";
     document.getElementById("error").textContent = gameName
       ? 'Unknown game: "' + gameName + '". Available: ' + Object.keys(GAMES).join(", ")
-      : "No game specified. Use ?game=bounce";
+      : "No game specified. Use ?game=bounce or ?id=gameId";
     document.getElementById("console").style.display = "none";
   } else {
     document.title = "Mono \u2014 " + gameName.charAt(0).toUpperCase() + gameName.slice(1);

--- a/play.html
+++ b/play.html
@@ -150,7 +150,7 @@
           colors: 4,
           readFile: function(name) { return modules[name] || null; },
         });
-        if (Mono.shader && Mono.shader.preset) Mono.shader.preset();
+        Mono.shader.preset();
       } catch(e) {
         console.error("Boot failed:", e);
         document.getElementById("error").style.display = "block";
@@ -167,7 +167,7 @@
   } else {
     document.title = "Mono \u2014 " + gameName.charAt(0).toUpperCase() + gameName.slice(1);
     Mono.boot("screen", { game: entry.path, colors: entry.colors }).then(function() {
-      if (Mono.shader && Mono.shader.preset) Mono.shader.preset();
+      Mono.shader.preset();
     }).catch(function(e) {
       console.error("Boot failed:", e);
       document.getElementById("error").style.display = "block";

--- a/play.html
+++ b/play.html
@@ -134,11 +134,17 @@
         document.title = "Mono \u2014 " + (data.title || "Game");
         document.getElementById("back-btn").href = "/";
 
-        var files = {};
+        var mainSrc = "";
+        var modules = {};
         for (var f of data.files) {
-          files[f.name] = f.content;
+          if (f.name === "main.lua") {
+            mainSrc = f.content;
+          } else if (f.name.endsWith(".lua")) {
+            modules[f.name] = f.content;
+          }
         }
-        await Mono.boot("screen", { files: files, colors: 4 });
+        if (!mainSrc) throw new Error("No main.lua in published files");
+        await Mono.boot("screen", { source: mainSrc, modules: modules, colors: 4 });
         if (Mono.shader && Mono.shader.preset) Mono.shader.preset();
       } catch(e) {
         console.error("Boot failed:", e);


### PR DESCRIPTION
## Summary
- **dev/index.html**: Publish section in Game Settings — headless test gate, publish/unpublish via Worker API, status badge with version display
- **index.html**: Public game gallery (Poki-style 3-col grid) querying Firestore for published games with thumbnails
- **play.html**: Support `?id=` param to load and play published games from R2

Depends on: monogame-storage/mono-api feat/publish branch

## Test plan
- [ ] Open dev page, create a game with main.lua, go to Settings → Publish
- [ ] Verify headless test runs before publish API call
- [ ] Visit root page, confirm published games appear in grid
- [ ] Click a game card, verify it loads in play.html via `?id=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)