### PR TITLE
fix(android): set launchMode=singleTask

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         <activity
             android:name="com.mono.game.MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
             android:screenOrientation="portrait">
             <intent-filter>


### PR DESCRIPTION
## Summary

- Add `android:launchMode="singleTask"` to MainActivity in the Android template manifest

Without this, tapping the launcher icon while the game is in the background can create a second Activity instance, leading to duplicate WebViews, audio overlap, and wasted memory. `singleTask` ensures the existing instance is brought to front instead.

## Test plan

- [ ] Build the Android template APK and install on a device
- [ ] Launch the game, press Home, then tap the launcher icon again — verify the existing instance resumes rather than creating a new one
- [ ] Verify deep links / intent handling still works correctly with singleTask

🤖 Generated with [Claude Code](https://claude.com/claude-code)