### PR TITLE
feat(engine): prevent screen sleep during gameplay

### DIFF
--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -14,13 +14,21 @@ var Mono = (() => {
   let wakeLock = null;
   async function requestWakeLock() {
     try {
-      if (navigator.wakeLock) wakeLock = await navigator.wakeLock.request("screen");
+      if (typeof navigator !== "undefined" && navigator.wakeLock)
+        wakeLock = await navigator.wakeLock.request("screen");
     } catch {}
   }
   async function releaseWakeLock() {
     try {
       if (wakeLock) { await wakeLock.release(); wakeLock = null; }
     } catch {}
+  }
+  // Re-acquire wake lock when tab becomes visible (browser releases it on hide)
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "visible" && wakeLock === null && _loopId)
+        requestWakeLock();
+    });
   }
 
   // --- Color palette ---
@@ -1218,9 +1226,6 @@ end
     _tickFn = tick;
     _loopId = requestAnimationFrame(tick);
     requestWakeLock();
-    document.addEventListener("visibilitychange", () => {
-      if (document.visibilityState === "visible" && _loopId) requestWakeLock();
-    });
   };
 
   API.suspend = () => {

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -10,6 +10,19 @@ var Mono = (() => {
 
   const W = 160, H = 120, FPS = 30, FRAME_MS = 1000 / FPS;
 
+  // --- Wake Lock (prevent screen sleep during gameplay) ---
+  let wakeLock = null;
+  async function requestWakeLock() {
+    try {
+      if (navigator.wakeLock) wakeLock = await navigator.wakeLock.request("screen");
+    } catch {}
+  }
+  async function releaseWakeLock() {
+    try {
+      if (wakeLock) { await wakeLock.release(); wakeLock = null; }
+    } catch {}
+  }
+
   // --- Color palette ---
   function buildPalette(bits) {
     const n = 1 << bits;  // 2, 4, or 16
@@ -1204,20 +1217,26 @@ end
     }
     _tickFn = tick;
     _loopId = requestAnimationFrame(tick);
+    requestWakeLock();
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "visible" && _loopId) requestWakeLock();
+    });
   };
 
   API.suspend = () => {
     if (_loopId) { cancelAnimationFrame(_loopId); _loopId = null; }
     sfxStop();
+    releaseWakeLock();
   };
 
   API.resume = () => {
-    if (!_loopId && _tickFn && _lua) { _tickFn(); }
+    if (!_loopId && _tickFn && _lua) { _tickFn(); requestWakeLock(); }
   };
 
   API.stop = () => {
     if (_loopId) { cancelAnimationFrame(_loopId); _loopId = null; }
     _tickFn = null;
+    releaseWakeLock();
     if (_lua) { _lua.global.close(); _lua = null; }
     paused = false;
     pauseEnabled = true;


### PR DESCRIPTION
## Summary

Wake Lock API로 게임 플레이 중 화면 꺼짐 방지.

- `boot()` → wake lock 요청
- `stop()` / `suspend()` → 해제
- `resume()` → 재요청
- `visibilitychange` → 탭 복귀 시 재요청
- API 미지원 브라우저 → 무시 (try/catch)

Android WebView는 이미 `FLAG_KEEP_SCREEN_ON`으로 처리 중.

Closes #76

## Test plan

- [ ] Chrome에서 게임 실행 → 화면 안 꺼짐
- [ ] 게임 정지 → wake lock 해제 확인 (DevTools > Application > Wake Lock)
- [ ] 탭 전환 후 복귀 → wake lock 재획득
- [ ] Safari/Firefox 미지원 → 에러 없이 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)