### PR TITLE
fix: motion_x negation + scrolling grid demo

### DIFF
--- a/demo/motion/main.lua
+++ b/demo/motion/main.lua
@@ -1,5 +1,5 @@
 -- Motion Sensor Demo
--- Tilt your device to move the ball. Shows accelerometer + gyroscope data.
+-- Tilt your device to move the ball over a scrolling grid.
 local scr = screen()
 
 function _init()
@@ -7,19 +7,20 @@ function _init()
 end
 
 local ball_x, ball_y
+local cam_x, cam_y = 0, 0
 local trail = {}
 local MAX_TRAIL = 20
 local mx, my, mz = 0, 0, 0
 local ga, gb, gg = 0, 0, 0
 local enabled = false
+local GRID = 16 -- grid cell size
 
 function _start()
-  ball_x = SCREEN_W / 2
-  ball_y = SCREEN_H / 2
+  ball_x = 0
+  ball_y = 0
 end
 
 function _update()
-  -- Read sensors once per frame
   mx = motion_x()
   my = motion_y()
   mz = motion_z()
@@ -28,15 +29,13 @@ function _update()
   gg = gyro_gamma()
   enabled = motion_enabled() == 1
 
-  -- Move ball with accelerometer tilt
+  -- Move ball with tilt (world coords, no clamp)
   ball_x = ball_x + mx * 3
   ball_y = ball_y + my * 3
 
-  -- Clamp to screen
-  if ball_x < 4 then ball_x = 4 end
-  if ball_x > SCREEN_W - 4 then ball_x = SCREEN_W - 4 end
-  if ball_y < 4 then ball_y = 4 end
-  if ball_y > SCREEN_H - 4 then ball_y = SCREEN_H - 4 end
+  -- Camera follows ball
+  cam_x = ball_x - SCREEN_W / 2
+  cam_y = ball_y - SCREEN_H / 2
 
   -- Trail
   table.insert(trail, 1, { x = ball_x, y = ball_y })
@@ -45,11 +44,21 @@ end
 
 function _draw()
   cls(scr, 0)
+  cam(cam_x, cam_y)
 
-  -- Crosshair at center
-  local cx, cy = SCREEN_W / 2, SCREEN_H / 2
-  line(scr, cx - 10, cy, cx + 10, cy, 2)
-  line(scr, cx, cy - 10, cx, cy + 10, 2)
+  -- Grid background (infinite feel)
+  local gx0 = math.floor(cam_x / GRID) * GRID
+  local gy0 = math.floor(cam_y / GRID) * GRID
+  for gx = gx0, gx0 + SCREEN_W + GRID, GRID do
+    line(scr, gx, gy0, gx, gy0 + SCREEN_H + GRID, 2)
+  end
+  for gy = gy0, gy0 + SCREEN_H + GRID, GRID do
+    line(scr, gx0, gy, gx0 + SCREEN_W + GRID, gy, 2)
+  end
+
+  -- Origin marker
+  line(scr, -6, 0, 6, 0, 4)
+  line(scr, 0, -6, 0, 6, 4)
 
   -- Trail (fading)
   for i = #trail, 1, -1 do
@@ -61,20 +70,23 @@ function _draw()
   -- Ball
   circf(scr, math.floor(ball_x), math.floor(ball_y), 3, 15)
 
-  -- Accelerometer
+  -- HUD (camera-independent)
+  cam(0, 0)
+
   local col = enabled and 15 or 5
   text(scr, "MOTION", 2, 2, 8)
   text(scr, "X:" .. string.format("%.2f", mx), 2, 12, col)
   text(scr, "Y:" .. string.format("%.2f", my), 2, 20, col)
   text(scr, "Z:" .. string.format("%.2f", mz), 2, 28, col)
 
-  -- Gyroscope
   text(scr, "GYRO", 2, 40, 8)
   text(scr, "A:" .. math.floor(ga), 2, 50, 11)
   text(scr, "B:" .. math.floor(gb), 2, 58, 11)
   text(scr, "G:" .. math.floor(gg), 2, 66, 11)
 
-  -- Status
+  -- Position
+  text(scr, math.floor(ball_x) .. "," .. math.floor(ball_y), SCREEN_W - 2, 2, 5, ALIGN_RIGHT)
+
   if not enabled then
     text(scr, "TILT DEVICE", 0, SCREEN_H - 10, 5, ALIGN_HCENTER)
   end

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -529,7 +529,7 @@ var Mono = (() => {
       const a = e.accelerationIncludingGravity;
       if (!a) return;
       motionEnabled = true;
-      motionX = Math.max(-1, Math.min(1, (a.x || 0) / 9.8)); // W3C spec: tilt right = positive x
+      motionX = Math.max(-1, Math.min(1, -(a.x || 0) / 9.8)); // negated: tilt right = positive screen x
       motionY = Math.max(-1, Math.min(1, (a.y || 0) / 9.8));
       motionZ = Math.max(-1, Math.min(1, (a.z || 0) / 9.8));
     });


### PR DESCRIPTION
## Summary

- **Restore motion_x negation** — `accelerationIncludingGravity.x` is negative when tilted right on Android Chrome. Verified on physical device that `-a.x` gives correct screen-coordinate mapping.
- **Scrolling grid demo** — Infinite grid background that moves with tilt, making sensor response clearly visible. Camera follows ball, origin marker at (0,0), position display.

## Why the negation was needed

W3C spec describes `acceleration` (device-relative), but we use `accelerationIncludingGravity` (gravity-relative) which has opposite sign for x-axis tilt. Physical testing confirmed:
- Tilt right → `a.x` is negative → negate to get positive screen x ✓
- Tilt forward → `a.y` is positive → no negation needed ✓

## Test plan

- [x] Android Chrome — tilt right = ball moves right
- [x] Android Chrome — tilt forward = ball moves down
- [x] Headless `--motion` injection passes
- [x] Grid scrolls visibly with small sensor changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)