### PR TITLE
feat: opt-in local save for AI master key

### DIFF
--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -1157,6 +1157,24 @@
 .aip-mk-btn:hover { background: #444; }
 .aip-mk-btn.danger { background: transparent; border: 1px solid #662222; color: #ff6666; }
 .aip-mk-btn.danger:hover { background: #1a0000; }
+.aip-mk-save-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #aaa;
+  cursor: pointer;
+  user-select: none;
+  margin-top: 2px;
+}
+.aip-mk-save-row input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: #6c6;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.aip-mk-save-hint { font-size: 11px; color: #555; }
 .aip-mk-status {
   font-size: 11px;
   margin-top: 4px;

--- a/dev/index.html
+++ b/dev/index.html
@@ -252,6 +252,11 @@
           <button class="aip-mk-btn" id="aip-mk-action" style="display:none">Change</button>
         </div>
         <div class="aip-strength" id="aip-strength"></div>
+        <label class="aip-mk-save-row">
+          <input type="checkbox" id="aip-mk-save-local" checked>
+          <span>Save on this device</span>
+          <span class="aip-mk-save-hint">Unchecked: key clears when you close this tab.</span>
+        </label>
         <div class="aip-mk-status" id="aip-mk-status"></div>
         <button class="aip-mk-btn danger" id="aip-mk-reset" style="display:none">Reset all providers</button>
       </div>

--- a/dev/js/editor.js
+++ b/dev/js/editor.js
@@ -7,7 +7,7 @@ import {
   doc,
   getDoc,
 } from "https://www.gstatic.com/firebasejs/11.7.1/firebase-firestore.js";
-import { decryptData, updateModelSelector, saveProviders, openAIProviders } from './settings.js';
+import { decryptData, updateModelSelector, saveProviders, openAIProviders, getVaultPp } from './settings.js';
 import { initEditorAI, renderChatHistory, clearEngineError } from './editor-ai.js';
 import { initEditorPlay, stopGame } from './editor-play.js';
 import { initEditorFiles } from './editor-files.js';
@@ -153,12 +153,13 @@ export async function openEditor(gameId, title, desc) {
   } catch {}
 
   // Load AI providers if needed
-  if (state.aiProviders.length === 0 && localStorage.getItem("mono_vault_pp")) {
+  const vaultPp = getVaultPp();
+  if (state.aiProviders.length === 0 && vaultPp) {
     try {
       const uid = state.auth.currentUser.uid;
       const snap = await getDoc(doc(state.db, "users", uid, "settings", "ai"));
       if (snap.exists() && snap.data().encrypted) {
-        state.aiProviders = await decryptData(localStorage.getItem("mono_vault_pp"), snap.data().encrypted);
+        state.aiProviders = await decryptData(vaultPp, snap.data().encrypted);
         updateModelSelector();
       }
     } catch {}

--- a/dev/js/settings.js
+++ b/dev/js/settings.js
@@ -157,8 +157,7 @@ function renderMasterKeyState() {
   const status = document.getElementById("aip-mk-status");
   const subtitle = document.getElementById("aip-mk-subtitle");
   const strength = document.getElementById("aip-strength");
-  const saveLocal = document.getElementById("aip-mk-save-local");
-  if (saveLocal) saveLocal.checked = getSaveLocalPref();
+  document.getElementById("aip-mk-save-local").checked = getSaveLocalPref();
 
   strength.textContent = "";
   strength.className = "aip-strength";
@@ -288,14 +287,10 @@ export function initSettings() {
 
   // Save-local checkbox
   document.getElementById("aip-mk-save-local").addEventListener("change", (e) => {
-    const enabled = e.target.checked;
-    setSaveLocalPref(enabled);
+    setSaveLocalPref(e.target.checked);
     const pp = getVaultPp();
-    if (enabled && pp) {
-      localStorage.setItem("mono_vault_pp", pp);
-    } else if (!enabled) {
-      localStorage.removeItem("mono_vault_pp");
-    }
+    if (pp) setVaultPp(pp);
+    else localStorage.removeItem("mono_vault_pp");
   });
 
   // Master key action

--- a/dev/js/settings.js
+++ b/dev/js/settings.js
@@ -42,10 +42,40 @@ export async function decryptData(passphrase, b64) {
   return JSON.parse(new TextDecoder().decode(decrypted));
 }
 
+// ── Master key persistence ──
+// If "save on this device" is enabled, pp is kept in localStorage.
+// If disabled, pp lives only in state.vaultPp (lost on reload / tab close).
+
+function getSaveLocalPref() {
+  return localStorage.getItem("mono_vault_save_local") !== "0";
+}
+
+function setSaveLocalPref(enabled) {
+  localStorage.setItem("mono_vault_save_local", enabled ? "1" : "0");
+}
+
+export function getVaultPp() {
+  return state.vaultPp || localStorage.getItem("mono_vault_pp") || "";
+}
+
+function setVaultPp(pp) {
+  state.vaultPp = pp;
+  if (getSaveLocalPref()) {
+    localStorage.setItem("mono_vault_pp", pp);
+  } else {
+    localStorage.removeItem("mono_vault_pp");
+  }
+}
+
+function clearVaultPp() {
+  state.vaultPp = null;
+  localStorage.removeItem("mono_vault_pp");
+}
+
 // ── Provider Storage ──
 
 export async function loadProviders() {
-  const pp = document.getElementById("aip-passphrase").value;
+  const pp = getVaultPp() || document.getElementById("aip-passphrase").value;
   if (!pp) { renderProviderList(); return; }
   try {
     const uid = state.auth.currentUser.uid;
@@ -62,7 +92,7 @@ export async function loadProviders() {
 }
 
 export async function saveProviders() {
-  const pp = localStorage.getItem("mono_vault_pp") || document.getElementById("aip-passphrase").value;
+  const pp = getVaultPp() || document.getElementById("aip-passphrase").value;
   if (!pp) { alert("Set a vault passphrase first"); return; }
   const encrypted = await encryptData(pp, state.aiProviders);
   const uid = state.auth.currentUser.uid;
@@ -120,13 +150,15 @@ async function checkOnlineProviders() {
 }
 
 function renderMasterKeyState() {
-  const pp = localStorage.getItem("mono_vault_pp") || "";
+  const pp = getVaultPp();
   const input = document.getElementById("aip-passphrase");
   const actionBtn = document.getElementById("aip-mk-action");
   const resetBtn = document.getElementById("aip-mk-reset");
   const status = document.getElementById("aip-mk-status");
   const subtitle = document.getElementById("aip-mk-subtitle");
   const strength = document.getElementById("aip-strength");
+  const saveLocal = document.getElementById("aip-mk-save-local");
+  if (saveLocal) saveLocal.checked = getSaveLocalPref();
 
   strength.textContent = "";
   strength.className = "aip-strength";
@@ -159,7 +191,7 @@ function renderMasterKeyState() {
     input.disabled = false;
     input.dataset.masked = "";
     input.placeholder = "Enter master key";
-    actionBtn.textContent = "Save";
+    actionBtn.textContent = "Set";
     actionBtn.style.display = "block";
     subtitle.textContent = "Required — set a master key to encrypt your API keys.";
     subtitle.style.color = "#ff6666";
@@ -171,8 +203,7 @@ function renderMasterKeyState() {
 export async function openAIProviders() {
   await checkOnlineProviders();
   renderMasterKeyState();
-  const pp = localStorage.getItem("mono_vault_pp");
-  if (pp) {
+  if (getVaultPp()) {
     await loadProviders();
   } else {
     state.aiProviders = [];
@@ -255,12 +286,24 @@ export function initSettings() {
   document.getElementById("btn-aip-back").addEventListener("click", () => { location.hash = "settings"; showView("devsettings"); });
   document.getElementById("aip-list").addEventListener("click", onProviderListClick);
 
+  // Save-local checkbox
+  document.getElementById("aip-mk-save-local").addEventListener("change", (e) => {
+    const enabled = e.target.checked;
+    setSaveLocalPref(enabled);
+    const pp = getVaultPp();
+    if (enabled && pp) {
+      localStorage.setItem("mono_vault_pp", pp);
+    } else if (!enabled) {
+      localStorage.removeItem("mono_vault_pp");
+    }
+  });
+
   // Master key action
   document.getElementById("aip-mk-action").addEventListener("click", async () => {
     const input = document.getElementById("aip-passphrase");
     const status = document.getElementById("aip-mk-status");
     const resetBtn = document.getElementById("aip-mk-reset");
-    const pp = localStorage.getItem("mono_vault_pp") || "";
+    const pp = getVaultPp();
 
     if (pp && input.dataset.masked === "1") {
       input.value = "";
@@ -286,7 +329,7 @@ export function initSettings() {
       input.dataset.verifying = "";
       input.placeholder = "Enter new master key";
       input.focus();
-      document.getElementById("aip-mk-action").textContent = "Save";
+      document.getElementById("aip-mk-action").textContent = "Set";
       status.textContent = "✓ Verified. Enter new key.";
       status.className = "aip-mk-status success";
       return;
@@ -301,7 +344,7 @@ export function initSettings() {
         const snap = await getDoc(doc(state.db, "users", uid, "settings", "ai"));
         const encrypted = snap.data().encrypted;
         state.aiProviders = await decryptData(newKey, encrypted);
-        localStorage.setItem("mono_vault_pp", newKey);
+        setVaultPp(newKey);
         status.textContent = "✓ Unlocked";
         status.className = "aip-mk-status success";
         resetBtn.style.display = "none";
@@ -326,7 +369,7 @@ export function initSettings() {
           state.aiProviders = await decryptData(oldKey, snap.data().encrypted);
         }
       } catch {}
-      localStorage.setItem("mono_vault_pp", newKey);
+      setVaultPp(newKey);
       await saveProviders();
       status.textContent = "✓ Master key changed and providers re-encrypted";
       status.className = "aip-mk-status success";
@@ -334,7 +377,7 @@ export function initSettings() {
       return;
     }
 
-    localStorage.setItem("mono_vault_pp", newKey);
+    setVaultPp(newKey);
     renderMasterKeyState();
     await loadProviders();
   });
@@ -347,6 +390,7 @@ export function initSettings() {
       await setDoc(doc(state.db, "users", uid, "settings", "ai"), { encrypted: null });
       state.hasOnlineProviders = false;
       state.aiProviders = [];
+      clearVaultPp();
       renderProviderList();
       renderMasterKeyState();
       document.getElementById("aip-mk-status").textContent = "Providers cleared";

--- a/dev/js/state.js
+++ b/dev/js/state.js
@@ -24,6 +24,7 @@ export const state = {
   aiProviders: [],       // { id, alias, model, key, url, isDefault }
   hasOnlineProviders: false,
   editingProviderIdx: -1,
+  vaultPp: null,         // in-memory master key when local-save is disabled
 
   // Local sync
   linkedDirHandle: null,


### PR DESCRIPTION
## Summary
- Add **Save on this device** checkbox next to the master-key input on `/dev/#settings/ai`. Default is checked (current behavior).
- When unchecked, the master key lives only in `state.vaultPp` for the current tab — it is removed from `localStorage` and must be re-entered after reload / tab close.
- Rename the initial master-key button label from **Save** → **Set** (Unlock / Verify / Change labels unchanged).

## Notes
- Preference stored in `localStorage["mono_vault_save_local"]` (`"1"` / `"0"`); absence → enabled (opt-out, not opt-in).
- Toggle fires immediately: checking writes the in-memory pp to `localStorage`, unchecking removes it.
- All direct `localStorage` accesses for `mono_vault_pp` are now funneled through `getVaultPp / setVaultPp / clearVaultPp` helpers in `settings.js`, including the one in `editor.js`.

## Test plan
- [ ] Fresh account: set master key with checkbox **on** → reload → still unlocked.
- [ ] Uncheck after setting → reload → prompted for master key, providers still decrypt after re-entry.
- [ ] Set checkbox to **off** before entering a key → Set → reload → key gone, providers locked.
- [ ] Toggle checkbox while a key is in memory → verify `localStorage["mono_vault_pp"]` appears/disappears in DevTools.
- [ ] Change master key flow (Change → Verify → Set) still re-encrypts providers and the button reads **Set**.
- [ ] Reset all providers clears both `state.vaultPp` and `localStorage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)