### PR TITLE
fix: scope AI vault keys per-uid

### DIFF
--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -57,7 +57,20 @@ initEditor();
 
 // ── Auth state → routing ──
 
+// One-time cleanup of pre-uid-scoped vault keys (ALPHA, no migration).
+localStorage.removeItem("mono_vault_pp");
+localStorage.removeItem("mono_vault_save_local");
+
+let lastUid = null;
 onAuthStateChanged(state.auth, async (user) => {
+  const newUid = user?.uid || null;
+  if (newUid !== lastUid) {
+    state.vaultPp = null;
+    state.aiProviders = [];
+    state.hasOnlineProviders = false;
+  }
+  lastUid = newUid;
+
   if (user) {
     renderDashboard(user);
     listenGames(user.uid);

--- a/dev/js/settings.js
+++ b/dev/js/settings.js
@@ -43,33 +43,51 @@ export async function decryptData(passphrase, b64) {
 }
 
 // ── Master key persistence ──
-// If "save on this device" is enabled, pp is kept in localStorage.
-// If disabled, pp lives only in state.vaultPp (lost on reload / tab close).
+// Keys are scoped per-uid so multiple accounts on the same browser
+// don't collide. If "save on this device" is enabled, pp is kept in
+// localStorage; otherwise pp lives only in state.vaultPp (lost on
+// reload / tab close).
+
+function currentUid() {
+  return state.auth?.currentUser?.uid || null;
+}
+
+function ppKey(uid) { return `mono_vault_pp_${uid}`; }
+function savePrefKey(uid) { return `mono_vault_save_local_${uid}`; }
 
 function getSaveLocalPref() {
-  return localStorage.getItem("mono_vault_save_local") !== "0";
+  const uid = currentUid();
+  if (!uid) return true;
+  return localStorage.getItem(savePrefKey(uid)) !== "0";
 }
 
 function setSaveLocalPref(enabled) {
-  localStorage.setItem("mono_vault_save_local", enabled ? "1" : "0");
+  const uid = currentUid();
+  if (!uid) return;
+  localStorage.setItem(savePrefKey(uid), enabled ? "1" : "0");
 }
 
 export function getVaultPp() {
-  return state.vaultPp || localStorage.getItem("mono_vault_pp") || "";
+  const uid = currentUid();
+  if (!uid) return "";
+  return state.vaultPp || localStorage.getItem(ppKey(uid)) || "";
 }
 
 function setVaultPp(pp) {
+  const uid = currentUid();
+  if (!uid) return;
   state.vaultPp = pp;
   if (getSaveLocalPref()) {
-    localStorage.setItem("mono_vault_pp", pp);
+    localStorage.setItem(ppKey(uid), pp);
   } else {
-    localStorage.removeItem("mono_vault_pp");
+    localStorage.removeItem(ppKey(uid));
   }
 }
 
 function clearVaultPp() {
+  const uid = currentUid();
   state.vaultPp = null;
-  localStorage.removeItem("mono_vault_pp");
+  if (uid) localStorage.removeItem(ppKey(uid));
 }
 
 // ── Provider Storage ──
@@ -290,7 +308,10 @@ export function initSettings() {
     setSaveLocalPref(e.target.checked);
     const pp = getVaultPp();
     if (pp) setVaultPp(pp);
-    else localStorage.removeItem("mono_vault_pp");
+    else {
+      const uid = currentUid();
+      if (uid) localStorage.removeItem(ppKey(uid));
+    }
   });
 
   // Master key action


### PR DESCRIPTION
## Summary
Prevents cross-account leaks on shared browsers. Previously, the master key (`localStorage["mono_vault_pp"]`), the save-local preference, and the in-memory state (`state.vaultPp`, `state.aiProviders`, `state.hasOnlineProviders`) were all uid-agnostic. Signing in as a different user would inherit the previous user's decrypted providers and master key, causing new providers to be encrypted under the wrong passphrase and silently stored under the new uid.

## Changes
- `localStorage` keys now include a uid suffix: `mono_vault_pp_${uid}`, `mono_vault_save_local_${uid}`.
- `app.js` auth handler tracks last uid and clears `vaultPp / aiProviders / hasOnlineProviders` whenever the uid changes (sign-out or cross-account sign-in).
- Pre-uid-scoped legacy keys (`mono_vault_pp`, `mono_vault_save_local`) are removed once at startup. No migration — ALPHA stage, users re-enter their master key once.

## Test plan
- [ ] User A sets master key → sign out → User B signs in → Settings/AI shows **"No master key set"** (not A's key).
- [ ] User A keeps save-local on; User B keeps save-local off → each preference remembered independently.
- [ ] User A adds a provider, signs out, User B signs in → model selector empty (A's providers not visible).
- [ ] User A signs back in on same browser → master key auto-loaded from `mono_vault_pp_${uidA}`.
- [ ] Existing user with legacy `mono_vault_pp` key → re-enters master key once, new key stored under uid-scoped slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)