### PR TITLE
feat: BYOK Connections + agentic tool-use loop + live trace UI

### DIFF
--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -867,6 +867,13 @@
 .ai-provider-pill .pill-icon svg,
 .ai-provider-pill .pill-chev svg { width: 10px; height: 10px; }
 .ai-provider-pill .pill-chev { color: #666; display: flex; }
+.ai-provider-pill.empty {
+  background: transparent;
+  border: 1px dashed #555;
+  color: #ff9a4a;
+}
+.ai-provider-pill.empty:hover { background: #221a10; }
+.ai-provider-pill.empty .pill-icon { color: #ff9a4a; }
 
 /* ── AI tab: Input bar ── */
 .ai-input-bar {

--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -762,6 +762,14 @@
   gap: 2px;
   margin-top: 4px;
 }
+.ai-agent-text {
+  font-size: 12px;
+  color: #ccc;
+  white-space: pre-wrap;
+  line-height: 1.45;
+  margin-top: 6px;
+}
+.ai-agent-text:empty { display: none; }
 .ai-tool-line {
   font-family: 'JetBrains Mono', monospace;
   font-size: 10px;

--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -875,6 +875,64 @@
 .ai-provider-pill.empty:hover { background: #221a10; }
 .ai-provider-pill.empty .pill-icon { color: #ff9a4a; }
 
+/* Provider dropdown (custom, not native <select>) */
+.provider-menu-pop {
+  position: fixed;
+  min-width: 180px;
+  max-width: 280px;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  padding: 4px;
+  z-index: 1000;
+  font-family: 'Inter', sans-serif;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.provider-menu-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 10px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: #ccc;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+}
+.provider-menu-row:hover { background: #262626; color: #fff; }
+.provider-menu-row.active { color: #c9a0dc; }
+.provider-menu-row.active .provider-menu-dot { color: #c9a0dc; }
+.provider-menu-dot {
+  display: inline-block;
+  width: 10px;
+  text-align: center;
+  color: #555;
+  font-size: 9px;
+}
+.provider-menu-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.provider-menu-sep {
+  height: 1px;
+  background: #2a2a2a;
+  margin: 4px 2px;
+}
+.provider-menu-row.manage {
+  color: #6c6;
+  justify-content: center;
+}
+.provider-menu-row.manage:hover { color: #8d8; }
+
 /* ── AI tab: Input bar ── */
 .ai-input-bar {
   display: flex;

--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -933,6 +933,38 @@
 }
 .provider-menu-row.manage:hover { color: #8d8; }
 
+/* Add Provider form — model list fetch */
+.apf-model-name-row {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+}
+.apf-model-name-row input { flex: 1; }
+.apf-fetch-btn {
+  flex-shrink: 0;
+  height: 40px;
+  padding: 0 12px;
+  background: #2a2a2a;
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: #ccc;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.apf-fetch-btn:hover { background: #333; color: #fff; }
+.apf-fetch-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.apf-fetch-status {
+  display: block;
+  font-size: 11px;
+  margin-top: 4px;
+  min-height: 14px;
+}
+.apf-fetch-status.success { color: #6c6; }
+.apf-fetch-status.error   { color: #f66; }
+.apf-fetch-status.warn    { color: #fa3; }
+
 /* ── AI tab: Input bar ── */
 .ai-input-bar {
   display: flex;

--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -1462,6 +1462,22 @@
 }
 .apf-delete-btn.show { display: block; }
 .apf-delete-btn:hover { background: #1a0000; }
+.apf-duplicate-btn {
+  width: 100%;
+  height: 40px;
+  background: transparent;
+  border: 1px solid #2f4a66;
+  border-radius: 8px;
+  color: #6cb6ff;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  display: none;
+  margin-bottom: 8px;
+}
+.apf-duplicate-btn.show { display: block; }
+.apf-duplicate-btn:hover { background: #0f1a26; }
 
 /* ── Dev Settings view ── */
 .devsettings-topbar {

--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -1375,6 +1375,24 @@
 .aip-mk-status.success { color: #6c6; }
 .aip-mk-status.warn { color: #fa3; }
 .aip-divider { height: 1px; background: #222; }
+.apf-link {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 11px;
+  color: #888;
+  text-decoration: none;
+}
+.apf-link:hover { color: #c9a0dc; }
+.aip-reset-banner {
+  background: #3a2a1a;
+  color: #e6c08a;
+  border-left: 3px solid #c08a3a;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+  font-size: 12px;
+  line-height: 1.45;
+  border-radius: 4px;
+}
 .aip-provider-card {
   display: flex;
   align-items: center;

--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -756,20 +756,29 @@
   color: #777;
 }
 .ai-card-file.active { color: #aaa; }
-.ai-agent-tools {
+/* Live trace container — interleaves reasoning / tool / token events
+   in the working agent card. Each block coalesces consecutive deltas
+   of the same kind and finalizes when a different event arrives. */
+.ai-agent-live {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
   margin-top: 4px;
+}
+.ai-agent-live:empty { display: none; }
+.ai-agent-reasoning {
+  font-size: 11px;
+  color: #aaa;
+  font-style: italic;
+  white-space: pre-wrap;
+  line-height: 1.4;
 }
 .ai-agent-text {
   font-size: 12px;
   color: #ccc;
   white-space: pre-wrap;
   line-height: 1.45;
-  margin-top: 6px;
 }
-.ai-agent-text:empty { display: none; }
 
 /* Collapsed trace on completed agent cards — mirrors Claude.ai-style
    "Thought for N iterations" pull-down. Default hidden; expanded shows

--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -756,6 +756,33 @@
   color: #777;
 }
 .ai-card-file.active { color: #aaa; }
+.ai-agent-tools {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 4px;
+}
+.ai-tool-line {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: #888;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.ai-tool-line .ai-tool-spin {
+  display: inline-block;
+  width: 10px;
+  color: #c9a0dc;
+}
+.ai-tool-line.working .ai-tool-spin { animation: ai-tool-pulse 1s ease-in-out infinite; }
+.ai-tool-line.ok  .ai-tool-spin { color: #7bcf7b; }
+.ai-tool-line.err .ai-tool-spin { color: #e48686; }
+.ai-tool-line.err .ai-tool-text { color: #c97878; }
+@keyframes ai-tool-pulse {
+  0%, 100% { opacity: 0.3; }
+  50%      { opacity: 1;   }
+}
 .ai-card-stop {
   display: inline-flex;
   align-items: center;

--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -770,6 +770,46 @@
   margin-top: 6px;
 }
 .ai-agent-text:empty { display: none; }
+
+/* Collapsed trace on completed agent cards — mirrors Claude.ai-style
+   "Thought for N iterations" pull-down. Default hidden; expanded shows
+   the full reasoning + tool log in the same compact style used during
+   the working phase. */
+.ai-trace-toggle {
+  display: block;
+  margin-top: 8px;
+  padding: 0;
+  background: none;
+  border: none;
+  color: #888;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  text-align: left;
+  cursor: pointer;
+  user-select: none;
+}
+.ai-trace-toggle:hover { color: #c9a0dc; }
+.ai-trace {
+  margin-top: 6px;
+  padding: 6px 8px;
+  border-left: 2px solid #2a2a2a;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.ai-trace-reasoning {
+  font-size: 11px;
+  color: #aaa;
+  font-style: italic;
+  white-space: pre-wrap;
+  line-height: 1.4;
+}
+.ai-trace-text {
+  font-size: 12px;
+  color: #ddd;
+  white-space: pre-wrap;
+  line-height: 1.4;
+}
 .ai-tool-line {
   font-family: 'JetBrains Mono', monospace;
   font-size: 10px;

--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -806,6 +806,10 @@
   flex-direction: column;
   gap: 4px;
 }
+/* The `hidden` attribute's UA default (display:none) is outranked by
+   .ai-trace's explicit display:flex above, so a class-specificity rule
+   is required to actually hide the trace when collapsed. */
+.ai-trace[hidden] { display: none; }
 .ai-trace-reasoning {
   font-size: 11px;
   color: #aaa;

--- a/dev/index.html
+++ b/dev/index.html
@@ -121,27 +121,11 @@
           <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M12 19V5M5 12l7-7 7 7"/></svg>
         </button>
       </div>
-      <!-- Hidden model selector (opened via topbar provider pill) -->
-      <select class="ai-model-select" id="model-select" style="display:none">
-        <option value="kimi-latest">mono-alpha</option>
-        <optgroup label="Anthropic">
-          <option value="claude-opus-4">Claude Opus 4</option>
-          <option value="claude-sonnet-4">Claude Sonnet 4</option>
-          <option value="claude-haiku-3">Claude Haiku 3</option>
-        </optgroup>
-        <optgroup label="Google">
-          <option value="gemini-3.1-pro">Gemini 3.1 Pro</option>
-          <option value="gemini-3-pro">Gemini 3 Pro</option>
-          <option value="gemini-3-flash">Gemini 3 Flash</option>
-          <option value="gemini-2.5-pro">Gemini 2.5 Pro</option>
-          <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>
-        </optgroup>
-        <optgroup label="OpenAI">
-          <option value="gpt-5.3-codex">GPT-5.3 Codex</option>
-          <option value="o3">o3</option>
-          <option value="gpt-4.1">GPT-4.1</option>
-        </optgroup>
-      </select>
+      <!-- Hidden model selector (opened via topbar provider pill).
+           Populated entirely from registered BYOK providers by
+           settings.js updateModelSelector(). AI chat is gated on having
+           at least one provider. -->
+      <select class="ai-model-select" id="model-select" style="display:none"></select>
     </div>
 
     <!-- Play Tab -->

--- a/dev/index.html
+++ b/dev/index.html
@@ -285,6 +285,9 @@
             <option value="o3">o3</option>
             <option value="gpt-4.1">GPT-4.1</option>
           </optgroup>
+          <optgroup label="Proxy (OpenAI-compat)">
+            <option value="claude-code">Claude Code relay</option>
+          </optgroup>
           <optgroup label="Other">
             <option value="kimi-latest">Kimi</option>
             <option value="custom">Custom</option>

--- a/dev/index.html
+++ b/dev/index.html
@@ -265,7 +265,7 @@
     <div class="apf-content">
       <div class="apf-field">
         <label>Alias</label>
-        <input type="text" id="apf-alias" placeholder="My Kimi" maxlength="30">
+        <input type="text" id="apf-alias" placeholder="Nickname" maxlength="30">
       </div>
       <div class="apf-field">
         <label>Provider</label>

--- a/dev/index.html
+++ b/dev/index.html
@@ -300,6 +300,11 @@
         <span class="apf-hint">Optional — leave empty for default</span>
         <input type="text" id="apf-url" placeholder="https://api.openai.com/v1">
       </div>
+      <div class="apf-field">
+        <label>Custom Model Name</label>
+        <span class="apf-hint">Optional — override the model name sent in the request body (e.g. proxy-specific Claude ID)</span>
+        <input type="text" id="apf-model-name" placeholder="claude-sonnet-4-5-20250929">
+      </div>
       <div class="apf-toggle-row">
         <button class="apf-toggle" id="apf-default-toggle"></button>
         <span class="apf-toggle-label">Set as default</span>

--- a/dev/index.html
+++ b/dev/index.html
@@ -306,7 +306,12 @@
       <div class="apf-field">
         <label>Custom Model Name</label>
         <span class="apf-hint">Optional — override the model name sent in the request body (e.g. proxy-specific Claude ID)</span>
-        <input type="text" id="apf-model-name" placeholder="claude-sonnet-4-5-20250929">
+        <div class="apf-model-name-row">
+          <input type="text" id="apf-model-name" list="apf-model-name-list" placeholder="claude-sonnet-4-5-20250929">
+          <button type="button" class="apf-fetch-btn" id="btn-apf-fetch-models" title="Fetch model list from Base URL">🔍 Fetch</button>
+        </div>
+        <datalist id="apf-model-name-list"></datalist>
+        <span class="apf-fetch-status" id="apf-fetch-status"></span>
       </div>
       <div class="apf-toggle-row">
         <button class="apf-toggle" id="apf-default-toggle"></button>

--- a/dev/index.html
+++ b/dev/index.html
@@ -192,7 +192,7 @@
           </div>
         </div>
         <div class="game-section">
-          <span class="game-section-label">AI Provider</span>
+          <span class="game-section-label">AI Assistant</span>
           <div class="game-provider-row">
             <span class="game-provider-name" id="game-provider-name">Default</span>
             <button class="game-provider-link" id="btn-game-aip">Change</button>
@@ -223,11 +223,11 @@
     </div>
   </div>
 
-  <!-- ── AI Providers View ── -->
+  <!-- ── AI Assistant / Connections View ── -->
   <div id="view-ai-providers" class="view">
     <div class="aip-topbar">
       <button id="btn-aip-back">‹</button>
-      <span>AI Providers</span>
+      <span>AI Assistant</span>
     </div>
     <div class="aip-content">
       <div class="aip-passphrase-section" id="aip-mk-section">
@@ -249,7 +249,7 @@
       <div class="aip-divider"></div>
       <span class="aip-label">Providers</span>
       <div id="aip-list"></div>
-      <button class="aip-add-btn" id="btn-aip-add">+ Add Provider</button>
+      <button class="aip-add-btn" id="btn-aip-add">+ Add Connection</button>
     </div>
   </div>
 
@@ -328,7 +328,7 @@
       <div class="devsettings-item" id="btn-ai-providers">
         <div class="devsettings-item-left">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><circle cx="12" cy="5" r="4"/></svg>
-          <span class="devsettings-item-label">AI Providers</span>
+          <span class="devsettings-item-label">AI Assistant</span>
         </div>
         <span class="devsettings-item-arrow">›</span>
       </div>

--- a/dev/index.html
+++ b/dev/index.html
@@ -253,65 +253,46 @@
     </div>
   </div>
 
-  <!-- ── Add/Edit Provider View ── -->
+  <!-- ── Add/Edit Connection View ── -->
   <div id="view-add-provider" class="view">
     <div class="apf-topbar">
       <div class="apf-topbar-left">
         <button class="apf-back" id="btn-apf-back">‹</button>
-        <span id="apf-title">Add Provider</span>
+        <span id="apf-title">Add Connection</span>
       </div>
       <button class="apf-save" id="btn-apf-save">Save</button>
     </div>
     <div class="apf-content">
       <div class="apf-field">
         <label>Alias</label>
-        <input type="text" id="apf-alias" placeholder="My Codex" maxlength="30">
+        <input type="text" id="apf-alias" placeholder="My Kimi" maxlength="30">
       </div>
       <div class="apf-field">
-        <label>Model</label>
-        <select id="apf-model">
-          <optgroup label="Anthropic">
-            <option value="claude-opus-4">Claude Opus 4</option>
-            <option value="claude-sonnet-4">Claude Sonnet 4</option>
-            <option value="claude-haiku-4.5">Claude Haiku 4.5</option>
-            <option value="claude-haiku-3">Claude Haiku 3</option>
-          </optgroup>
-          <optgroup label="Google">
-            <option value="gemini-2.5-pro">Gemini 2.5 Pro</option>
-            <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>
-          </optgroup>
-          <optgroup label="OpenAI">
-            <option value="gpt-5.3-codex">GPT-5.3 Codex</option>
-            <option value="o3">o3</option>
-            <option value="gpt-4.1">GPT-4.1</option>
-          </optgroup>
-          <optgroup label="Proxy (OpenAI-compat)">
-            <option value="claude-code">Claude Code relay</option>
-          </optgroup>
-          <optgroup label="Other">
-            <option value="kimi-latest">Kimi</option>
-            <option value="custom">Custom</option>
-          </optgroup>
+        <label>Provider</label>
+        <select id="apf-provider">
+          <!-- Populated from /config at load time. -->
         </select>
+      </div>
+      <div class="apf-field" id="apf-base-url-field">
+        <label>Base URL</label>
+        <span class="apf-hint" id="apf-base-url-hint">Optional — leave empty for provider default</span>
+        <input type="text" id="apf-base-url" placeholder="https://api.example.com">
       </div>
       <div class="apf-field">
         <label>API Key</label>
         <input type="password" id="apf-key" placeholder="sk-...">
       </div>
       <div class="apf-field">
-        <label>Base URL</label>
-        <span class="apf-hint">Optional — leave empty for default</span>
-        <input type="text" id="apf-url" placeholder="https://api.openai.com/v1">
-      </div>
-      <div class="apf-field">
-        <label>Custom Model Name</label>
-        <span class="apf-hint">Optional — override the model name sent in the request body (e.g. proxy-specific Claude ID)</span>
+        <label>Model</label>
         <div class="apf-model-name-row">
-          <input type="text" id="apf-model-name" list="apf-model-name-list" placeholder="claude-sonnet-4-5-20250929">
-          <button type="button" class="apf-fetch-btn" id="btn-apf-fetch-models" title="Fetch model list from Base URL">🔍 Fetch</button>
+          <select id="apf-model-select">
+            <option value="">— Fetch models to populate —</option>
+          </select>
+          <button type="button" class="apf-fetch-btn" id="btn-apf-fetch-models" title="Query the provider's /models endpoint">🔍 Fetch</button>
         </div>
-        <datalist id="apf-model-name-list"></datalist>
+        <input type="text" id="apf-model-manual" placeholder="Type model id directly" style="display:none;margin-top:6px">
         <span class="apf-fetch-status" id="apf-fetch-status"></span>
+        <a href="#" class="apf-link" id="btn-apf-model-manual-toggle">Enter model manually →</a>
       </div>
       <div class="apf-toggle-row">
         <button class="apf-toggle" id="apf-default-toggle"></button>
@@ -322,8 +303,8 @@
         <div class="apf-test-result-title" id="apf-test-title"></div>
         <div class="apf-test-result-detail" id="apf-test-detail"></div>
       </div>
-      <button class="apf-duplicate-btn" id="btn-apf-duplicate">Duplicate Provider</button>
-      <button class="apf-delete-btn" id="btn-apf-delete">Delete Provider</button>
+      <button class="apf-duplicate-btn" id="btn-apf-duplicate">Duplicate Connection</button>
+      <button class="apf-delete-btn" id="btn-apf-delete">Delete Connection</button>
     </div>
   </div>
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -322,6 +322,7 @@
         <div class="apf-test-result-title" id="apf-test-title"></div>
         <div class="apf-test-result-detail" id="apf-test-detail"></div>
       </div>
+      <button class="apf-duplicate-btn" id="btn-apf-duplicate">Duplicate Provider</button>
       <button class="apf-delete-btn" id="btn-apf-delete">Delete Provider</button>
     </div>
   </div>

--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -66,7 +66,7 @@ onAuthStateChanged(state.auth, async (user) => {
   const newUid = user?.uid || null;
   if (newUid !== lastUid) {
     state.vaultPp = null;
-    state.aiProviders = [];
+    state.aiConnections = [];
     state.hasOnlineProviders = false;
   }
   lastUid = newUid;

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -3,6 +3,7 @@
 import { state, esc, chatTime } from './state.js';
 import { apiFetch, saveChatHistory } from './api.js';
 import { runHeadlessTest } from './editor-play.js';
+import { openAIProviders } from './settings.js';
 
 // ── Card builders ──
 
@@ -237,6 +238,28 @@ export async function sendMessage(autoMsg) {
   const input = document.getElementById("editor-msg");
   const msg = autoMsg || input.value.trim();
   if (!msg) return;
+
+  // Chat is BYOK-only. Without a registered provider there is no key
+  // to send the request with — short-circuit here and point the user
+  // at the provider settings instead of letting the request fail on
+  // the server.
+  const selectedValue = document.getElementById("model-select").value;
+  if (!selectedValue.startsWith("provider:")) {
+    const chatEl = document.getElementById("editor-chat");
+    chatEl.innerHTML += errorCard(
+      "Register an AI provider in Settings → AI Providers, then pick it from the pill above to enable chat.",
+      "NO PROVIDER",
+      false,
+    );
+    chatEl.scrollTop = chatEl.scrollHeight;
+    if (!autoMsg) {
+      // Keep the user's draft so they can retry after registering.
+      input.focus();
+    }
+    openAIProviders();
+    return;
+  }
+
   if (!autoMsg) { input.value = ""; input.style.height = "auto"; }
 
   const chat = document.getElementById("editor-chat");
@@ -247,16 +270,10 @@ export async function sendMessage(autoMsg) {
   state.chatHistory.push({ role: "user", content: msg });
 
   try {
-    const selectedValue = document.getElementById("model-select").value;
-    let model, byok;
-    if (selectedValue.startsWith("provider:")) {
-      const provider = state.aiProviders.find(p => p.id === selectedValue.slice(9));
-      if (provider) {
-        model = provider.model;
-        byok = { key: provider.key, url: provider.url || undefined };
-      }
-    }
-    if (!model) model = selectedValue;
+    const provider = state.aiProviders.find(p => p.id === selectedValue.slice(9));
+    if (!provider) throw new Error("Selected provider no longer exists — pick another one from the pill above.");
+    const model = provider.model;
+    const byok = { key: provider.key, url: provider.url || undefined };
 
     console.group("[MONO Chat]");
     console.log("→ model:", model);

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -173,15 +173,15 @@ function monoTypingCard() {
   </div>`;
 }
 
-// Progress card for the /chat/agent streaming path. Tool activity
-// lines are appended into `.ai-agent-tools` as they stream in; the
-// final reply replaces the whole card via monoCard() once the
-// SSE stream sends `final`.
+// Progress card for the /chat/agent streaming path. Events (reasoning,
+// tool_start, tool_result, token deltas) land inside `.ai-agent-live`
+// in arrival order, so the user watches the same interleaved trace
+// that will later be folded into the completed card's collapsible.
+// On final the whole card is swapped for monoCardAgentCompleted().
 function monoAgentCard(id) {
   return `<div class="ai-card-mono working" id="${id}">
     <div class="ai-card-status working">MONO · working…</div>
-    <div class="ai-agent-tools"></div>
-    <div class="ai-agent-text"></div>
+    <div class="ai-agent-live"></div>
   </div>`;
 }
 
@@ -368,21 +368,47 @@ async function sendAgent(provider, msg, chat) {
   if (typing) typing.outerHTML = monoAgentCard(cardId);
   else chat.innerHTML += monoAgentCard(cardId);
   const card = document.getElementById(cardId);
-  const toolsEl = card?.querySelector(".ai-agent-tools");
-  const textEl = card?.querySelector(".ai-agent-text");
+  const liveEl = card?.querySelector(".ai-agent-live");
   const toolLines = new Map(); // tool_call id → row element
   chat.scrollTop = chat.scrollHeight;
 
-  const addToolLine = (id, text) => {
-    if (!toolsEl) return null;
-    const row = document.createElement("div");
-    row.className = "ai-tool-line working";
-    row.dataset.id = id;
-    row.innerHTML = `<span class="ai-tool-spin">◌</span><span class="ai-tool-text">${esc(text)}</span>`;
-    toolsEl.appendChild(row);
-    toolLines.set(id, row);
+  // Append into `.ai-agent-live` in arrival order. Consecutive reasoning
+  // or token events coalesce into the same block (typing-style growth);
+  // a new event type — tool call, next-turn reasoning after tools —
+  // starts a fresh block underneath so the trace reads top-to-bottom.
+  const appendLive = (kind, text, opts = {}) => {
+    if (!liveEl) return null;
+    const last = liveEl.lastElementChild;
+    if (kind === "reasoning") {
+      if (last?.classList.contains("ai-agent-reasoning") && last.dataset.finalized !== "1") {
+        last.append(text);
+      } else {
+        const el = document.createElement("div");
+        el.className = "ai-agent-reasoning";
+        el.textContent = "💭 " + text;
+        liveEl.appendChild(el);
+      }
+    } else if (kind === "text") {
+      if (last?.classList.contains("ai-agent-text") && last.dataset.finalized !== "1") {
+        last.append(text);
+      } else {
+        const el = document.createElement("div");
+        el.className = "ai-agent-text";
+        el.textContent = text;
+        liveEl.appendChild(el);
+      }
+    } else if (kind === "tool") {
+      // Starting a tool row closes whatever live reasoning / text is
+      // above so the next delta after the tool opens a fresh block.
+      for (const child of liveEl.children) child.dataset.finalized = "1";
+      const row = document.createElement("div");
+      row.className = "ai-tool-line working";
+      row.dataset.id = opts.id;
+      row.innerHTML = `<span class="ai-tool-spin">◌</span><span class="ai-tool-text">${esc(opts.label)}</span>`;
+      liveEl.appendChild(row);
+      toolLines.set(opts.id, row);
+    }
     chat.scrollTop = chat.scrollHeight;
-    return row;
   };
   const finishToolLine = (id, ok, summary) => {
     const row = toolLines.get(id);
@@ -407,9 +433,11 @@ async function sendAgent(provider, msg, chat) {
   let streamBuf = ""; // per-turn token buffer, flushed on tool call / final
   // Parallel data log of every SSE event — survives the DOM swap so the
   // completed card can render a collapsed trace of reasoning / mid-turn
-  // text / tool calls for user inspection.
+  // text / tool calls for user inspection. Reasoning deltas coalesce into
+  // the open entry (currentReasoningEntry) until a tool_start closes it.
   const trace = [];
   const traceToolById = new Map();
+  let currentReasoningEntry = null;
 
   try {
     const token = await state.auth.currentUser.getIdToken();
@@ -443,27 +471,27 @@ async function sendAgent(provider, msg, chat) {
 
     for await (const { event, data } of parseSSE(res)) {
       if (event === "reasoning") {
-        console.log("· reasoning:", data.text || "");
-        if (data.text) trace.push({ kind: "reasoning", text: data.text });
+        if (!data.text) continue;
+        // Live: grow the current reasoning block (coalesce deltas).
+        appendLive("reasoning", data.text);
+        // Trace: same coalescing rule so deltas become one block per turn.
+        if (currentReasoningEntry) {
+          currentReasoningEntry.text += data.text;
+        } else {
+          currentReasoningEntry = { kind: "reasoning", text: data.text };
+          trace.push(currentReasoningEntry);
+        }
       } else if (event === "token") {
         if (!data.text) continue;
-        // Accumulate into the per-turn buffer; flushed (one console.log)
-        // when the turn ends (tool_start or final) so the console stays
-        // readable while still preserving full visibility of the stream.
         streamBuf += data.text;
-        if (textEl) {
-          if (textEl.dataset.stale === "1") {
-            textEl.textContent = "";
-            textEl.dataset.stale = "";
-          }
-          textEl.textContent += data.text;
-          chat.scrollTop = chat.scrollHeight;
-        }
+        appendLive("text", data.text);
       } else if (event === "tool_start") {
         flushStream("pre-tool text", true);
         console.log("→ tool:", data.name, data.input);
-        if (textEl && textEl.textContent) textEl.dataset.stale = "1";
-        addToolLine(data.id, toolLineLabel(data.name, data.input));
+        // A tool call ends the current reasoning block: the next
+        // reasoning burst belongs to the next iteration.
+        currentReasoningEntry = null;
+        appendLive("tool", null, { id: data.id, label: toolLineLabel(data.name, data.input) });
         const entry = { kind: "tool", id: data.id, name: data.name, input: data.input, ok: null, summary: null };
         trace.push(entry);
         traceToolById.set(data.id, entry);

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -536,7 +536,18 @@ async function sendAgent(provider, msg, chat) {
       tokens: finalUsage?.total_tokens || 0,
     };
     const replacement = monoCardAgentCompleted(finalText, changedFiles, trace, stats);
-    if (card) card.outerHTML = replacement;
+    // Re-query by id — if anything else appended to chat during streaming
+    // (showEngineError, another message, ...) the `card` reference is
+    // stale and outerHTML= would mutate a detached node. Fall back to
+    // appending so the user always sees the completed card.
+    const liveCard = document.getElementById(cardId);
+    if (liveCard) {
+      liveCard.outerHTML = replacement;
+    } else {
+      console.warn("[MONO Agent] working card detached before final; appending");
+      chat.insertAdjacentHTML("beforeend", replacement);
+    }
+    console.log("← rendered:", { bytes: replacement.length, hasText: !!finalText });
     console.groupEnd();
 
     // Smoke test: if the agent edited any .lua file, run the headless

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -125,6 +125,7 @@ function monoAgentCard(id) {
   return `<div class="ai-card-mono working" id="${id}">
     <div class="ai-card-status working">MONO · working…</div>
     <div class="ai-agent-tools"></div>
+    <div class="ai-agent-text"></div>
   </div>`;
 }
 
@@ -312,6 +313,7 @@ async function sendAgent(provider, msg, chat) {
   else chat.innerHTML += monoAgentCard(cardId);
   const card = document.getElementById(cardId);
   const toolsEl = card?.querySelector(".ai-agent-tools");
+  const textEl = card?.querySelector(".ai-agent-text");
   const toolLines = new Map(); // tool_call id → row element
   chat.scrollTop = chat.scrollHeight;
 
@@ -370,8 +372,22 @@ async function sendAgent(provider, msg, chat) {
     for await (const { event, data } of parseSSE(res)) {
       if (event === "reasoning") {
         console.log("· reasoning:", (data.text || "").slice(0, 200));
+      } else if (event === "token") {
+        if (textEl && data.text) {
+          // Clear between iterations: if a tool call executed after the
+          // last token burst, the next burst is a fresh turn.
+          if (textEl.dataset.stale === "1") {
+            textEl.textContent = "";
+            textEl.dataset.stale = "";
+          }
+          textEl.textContent += data.text;
+          chat.scrollTop = chat.scrollHeight;
+        }
       } else if (event === "tool_start") {
         console.log("→ tool:", data.name, data.input);
+        // Any streamed text that preceded this tool call was inter-turn
+        // chatter — mark stale so the next token burst overwrites it.
+        if (textEl && textEl.textContent) textEl.dataset.stale = "1";
         addToolLine(data.id, toolLineLabel(data.name, data.input));
       } else if (event === "tool_result") {
         console.log("← tool:", data.name, data.ok ? "ok" : "err", data.summary);

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -273,10 +273,14 @@ export async function sendMessage(autoMsg) {
     const provider = state.aiProviders.find(p => p.id === selectedValue.slice(9));
     if (!provider) throw new Error("Selected provider no longer exists — pick another one from the pill above.");
     const model = provider.model;
-    const byok = { key: provider.key, url: provider.url || undefined };
+    const byok = {
+      key: provider.key,
+      url: provider.url || undefined,
+      modelName: provider.modelName || undefined,
+    };
 
     console.group("[MONO Chat]");
-    console.log("→ model:", model);
+    console.log("→ model:", model, byok.modelName ? `(override: ${byok.modelName})` : "");
     console.log("→ message:", msg);
     console.log("→ files:", state.currentFiles.map(f => f.name));
     console.groupEnd();

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -1,9 +1,22 @@
 // ── AI Tab: Chat, send message, test & fix ──
 
-import { state, esc, chatTime } from './state.js';
+import { state, esc, chatTime, API_URL } from './state.js';
 import { apiFetch, saveChatHistory } from './api.js';
 import { runHeadlessTest } from './editor-play.js';
 import { openAIProviders } from './settings.js';
+
+// Models whose server-side PROVIDERS entry has apiType=openai. Those
+// route to /chat/agent (SSE tool-use loop); anything else falls back
+// to the one-shot /chat endpoint via the legacy path in sendMessage.
+// Keep in sync with PROVIDERS in mono-api/src/index.js.
+const AGENT_MODELS = new Set([
+  "kimi-latest", "o3", "gpt-4.1",
+  "gpt-5.3-codex-apimart", "gpt-5.4-apimart",
+  "claude-code",
+]);
+function usesAgentPath(modelValue) {
+  return AGENT_MODELS.has(modelValue);
+}
 
 // ── Card builders ──
 
@@ -102,6 +115,29 @@ function monoTypingCard() {
     <div class="ai-card-status working">MONO · working…</div>
     <div class="ai-card-response" style="color:#888">Thinking…</div>
   </div>`;
+}
+
+// Progress card for the /chat/agent streaming path. Tool activity
+// lines are appended into `.ai-agent-tools` as they stream in; the
+// final reply replaces the whole card via monoCard() once the
+// SSE stream sends `final`.
+function monoAgentCard(id) {
+  return `<div class="ai-card-mono working" id="${id}">
+    <div class="ai-card-status working">MONO · working…</div>
+    <div class="ai-agent-tools"></div>
+  </div>`;
+}
+
+const TOOL_ICON = {
+  list_files: "📂",
+  read_file:  "📖",
+  write_file: "✏️",
+  delete_file:"🗑️",
+};
+
+function toolLineLabel(name, input) {
+  const p = input?.path ? ` ${input.path}` : "";
+  return `${TOOL_ICON[name] || "🔧"} ${name}${p}`;
 }
 
 function errorCard(msg, label = "ERROR", showFix = true) {
@@ -232,6 +268,176 @@ function updateUsageDisplay(data) {
   state.sessionTokens.total += usage.total_tokens || 0;
 }
 
+// ── Agent path (SSE tool-use loop) ──
+
+// Parse an SSE stream into { event, data } records. Yields each record
+// as it arrives. Follows the minimal SSE grammar used by /chat/agent:
+// one `event:` + one `data:` per frame, separated by blank lines.
+async function* parseSSE(response) {
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf("\n\n")) !== -1) {
+      const frame = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+      let event = "message", dataStr = "";
+      for (const line of frame.split("\n")) {
+        if (line.startsWith("event:")) event = line.slice(6).trim();
+        else if (line.startsWith("data:")) dataStr += line.slice(5).trim();
+      }
+      if (!dataStr) continue;
+      let data;
+      try { data = JSON.parse(dataStr); } catch { continue; }
+      yield { event, data };
+    }
+  }
+}
+
+async function sendAgent(provider, msg, chat) {
+  const model = provider.model;
+  const byok = {
+    key: provider.key,
+    url: provider.url || undefined,
+    modelName: provider.modelName || undefined,
+  };
+
+  const cardId = `mono-agent-${Date.now()}`;
+  const typing = document.getElementById("mono-typing");
+  if (typing) typing.outerHTML = monoAgentCard(cardId);
+  else chat.innerHTML += monoAgentCard(cardId);
+  const card = document.getElementById(cardId);
+  const toolsEl = card?.querySelector(".ai-agent-tools");
+  const toolLines = new Map(); // tool_call id → row element
+  chat.scrollTop = chat.scrollHeight;
+
+  const addToolLine = (id, text) => {
+    if (!toolsEl) return null;
+    const row = document.createElement("div");
+    row.className = "ai-tool-line working";
+    row.dataset.id = id;
+    row.innerHTML = `<span class="ai-tool-spin">◌</span><span class="ai-tool-text">${esc(text)}</span>`;
+    toolsEl.appendChild(row);
+    toolLines.set(id, row);
+    chat.scrollTop = chat.scrollHeight;
+    return row;
+  };
+  const finishToolLine = (id, ok, summary) => {
+    const row = toolLines.get(id);
+    if (!row) return;
+    row.classList.remove("working");
+    row.classList.add(ok ? "ok" : "err");
+    const spin = row.querySelector(".ai-tool-spin");
+    if (spin) spin.textContent = ok ? "✓" : "✗";
+    const txt = row.querySelector(".ai-tool-text");
+    if (txt && summary) txt.textContent = `${txt.textContent} — ${summary}`;
+  };
+
+  console.group("[MONO Agent]");
+  console.log("→ model:", model, byok.modelName ? `(override: ${byok.modelName})` : "");
+  console.log("→ message:", msg);
+
+  let finalText = "";
+  let changedList = [];
+  let finalUsage = null;
+  let errored = null;
+
+  try {
+    const token = await state.auth.currentUser.getIdToken();
+    const res = await fetch(`${API_URL}/chat/agent`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        gameId: state.currentGameId,
+        message: msg,
+        history: state.chatHistory.slice(0, -1),
+        model,
+        byok,
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`agent ${res.status}: ${body.slice(0, 200)}`);
+    }
+
+    for await (const { event, data } of parseSSE(res)) {
+      if (event === "reasoning") {
+        console.log("· reasoning:", (data.text || "").slice(0, 200));
+      } else if (event === "tool_start") {
+        console.log("→ tool:", data.name, data.input);
+        addToolLine(data.id, toolLineLabel(data.name, data.input));
+      } else if (event === "tool_result") {
+        console.log("← tool:", data.name, data.ok ? "ok" : "err", data.summary);
+        finishToolLine(data.id, data.ok, data.summary);
+      } else if (event === "final") {
+        finalText = data.text || "";
+        changedList = data.changed || [];
+        finalUsage = data.usage || null;
+        console.log("← final:", { iterations: data.iterations, changed: changedList.length });
+      } else if (event === "error") {
+        errored = data.message || "agent error";
+        console.error("← error:", data);
+      }
+    }
+
+    if (errored) throw new Error(errored);
+
+    // Re-sync changed files from R2 so state.currentFiles matches disk.
+    const changedFiles = [];
+    if (changedList.length) {
+      const deletes = changedList.filter(c => c.action === "delete");
+      const writes = changedList.filter(c => c.action === "write");
+      for (const d of deletes) {
+        const idx = state.currentFiles.findIndex(c => c.name === d.name);
+        if (idx >= 0) state.currentFiles.splice(idx, 1);
+        changedFiles.push({ name: d.name, _action: "deleted" });
+      }
+      await Promise.all(writes.map(async (w) => {
+        try {
+          const r = await apiFetch(`/games/${state.currentGameId}/files/${w.name}`);
+          if (!r.ok) return;
+          const text = await r.text();
+          const idx = state.currentFiles.findIndex(c => c.name === w.name);
+          const action = idx >= 0 ? "edited" : "created";
+          if (idx >= 0) state.currentFiles[idx].content = text;
+          else state.currentFiles.push({ name: w.name, content: text });
+          changedFiles.push({ name: w.name, _action: action });
+        } catch (e) {
+          console.warn("re-sync failed:", w.name, e);
+        }
+      }));
+      const { renderFileTree } = window._editorFiles || {};
+      if (renderFileTree) renderFileTree();
+    }
+
+    if (finalUsage) {
+      state.sessionTokens.prompt += finalUsage.prompt_tokens || 0;
+      state.sessionTokens.completion += finalUsage.completion_tokens || 0;
+      state.sessionTokens.total += finalUsage.total_tokens || 0;
+    }
+
+    state.chatHistory.push({ role: "assistant", content: finalText });
+    saveChatHistory();
+
+    const replacement = monoCard(finalText, changedFiles, "completed");
+    if (card) card.outerHTML = replacement;
+    console.groupEnd();
+  } catch (e) {
+    console.error("agent error:", e);
+    console.groupEnd();
+    const cardEl = document.getElementById(cardId);
+    if (cardEl) cardEl.outerHTML = errorCard(e.message, "AGENT ERROR", false);
+  }
+  chat.scrollTop = chat.scrollHeight;
+}
+
 // ── Send message ──
 
 export async function sendMessage(autoMsg) {
@@ -272,6 +478,15 @@ export async function sendMessage(autoMsg) {
   try {
     const provider = state.aiProviders.find(p => p.id === selectedValue.slice(9));
     if (!provider) throw new Error("Selected provider no longer exists — pick another one from the pill above.");
+
+    // OpenAI-compat providers run the full agentic tool-use loop on the
+    // server, streamed over SSE. Everything else falls back to one-shot
+    // /chat (which still handles anthropic / gemini / responses apiTypes).
+    if (usesAgentPath(provider.model)) {
+      await sendAgent(provider, msg, chat);
+      return;
+    }
+
     const model = provider.model;
     const byok = {
       key: provider.key,

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -305,7 +305,20 @@ export async function sendMessage(autoMsg) {
     console.log("← status:", res.status);
     console.log("← message:", data.message);
     console.log("← files:", data.files?.map(f => ({ name: f.name, size: f.content?.length || 0 })) || []);
-    if (data.usage) console.log("← usage:", data.usage);
+    if (data.usage) {
+      console.log("← usage:", data.usage);
+      // Anthropic prompt-cache telemetry — highlights the cache-hit ratio
+      // so it's obvious when the breakpoint is paying off.
+      const u = data.usage;
+      if (u.cache_read_input_tokens || u.cache_creation_input_tokens) {
+        const fresh = u.prompt_tokens || 0;
+        const cached = u.cache_read_input_tokens || 0;
+        const written = u.cache_creation_input_tokens || 0;
+        const total = fresh + cached;
+        const hitRatio = total > 0 ? Math.round((cached / total) * 100) : 0;
+        console.log(`← cache: ${cached}/${total} tokens reused (${hitRatio}% hit, ${written} newly cached)`);
+      }
+    }
     console.groupEnd();
 
     state.chatHistory.push({ role: "assistant", content: data.message });

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -352,13 +352,20 @@ function updateUsageDisplay(data) {
 
 // ── Agent path (SSE tool-use loop) ──
 
-// Parse an SSE stream into { event, data } records. Yields each record
-// as it arrives. Follows the minimal SSE grammar used by /chat/agent:
-// one `event:` + one `data:` per frame, separated by blank lines.
+// Parse an SSE stream into { event, data } records. Follows the
+// WHATWG SSE grammar: every `data:` line in a frame contributes a
+// value, and consecutive `data:` lines are joined with `\n` (not
+// concatenated tightly — that corrupts JSON whose values contain
+// embedded whitespace). Optional single space after the colon is
+// stripped per spec; preserves all other characters verbatim.
 async function* parseSSE(response) {
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buf = "";
+  const stripPrefix = (line, prefix) => {
+    const rest = line.slice(prefix.length);
+    return rest.startsWith(" ") ? rest.slice(1) : rest;
+  };
   while (true) {
     const { value, done } = await reader.read();
     if (done) break;
@@ -367,12 +374,15 @@ async function* parseSSE(response) {
     while ((idx = buf.indexOf("\n\n")) !== -1) {
       const frame = buf.slice(0, idx);
       buf = buf.slice(idx + 2);
-      let event = "message", dataStr = "";
+      let event = "message";
+      const dataLines = [];
       for (const line of frame.split("\n")) {
-        if (line.startsWith("event:")) event = line.slice(6).trim();
-        else if (line.startsWith("data:")) dataStr += line.slice(5).trim();
+        if (line.startsWith(":")) continue; // SSE comment
+        if (line.startsWith("event:")) event = stripPrefix(line, "event:").trim();
+        else if (line.startsWith("data:")) dataLines.push(stripPrefix(line, "data:"));
       }
-      if (!dataStr) continue;
+      if (dataLines.length === 0) continue;
+      const dataStr = dataLines.join("\n");
       let data;
       try { data = JSON.parse(dataStr); } catch { continue; }
       yield { event, data };
@@ -381,6 +391,13 @@ async function* parseSSE(response) {
 }
 
 async function sendAgent(connection, msg, chat) {
+  // Defensive guard — caller already checks state.aiConnections, but the
+  // user can delete the Connection between the lookup and now (rapid
+  // navigation, multi-tab edit). Bail with a clear error instead of
+  // crashing on `connection.provider`.
+  if (!connection?.provider || !connection?.model || !connection?.apiKey) {
+    throw new Error("Connection is invalid — re-pick or re-add it in Settings → AI Assistant.");
+  }
   const providerId = connection.provider;
   const model = connection.model;
   const byok = {
@@ -392,16 +409,22 @@ async function sendAgent(connection, msg, chat) {
   const typing = document.getElementById("mono-typing");
   if (typing) typing.outerHTML = monoAgentCard(cardId);
   else chat.innerHTML += monoAgentCard(cardId);
-  const card = document.getElementById(cardId);
-  const liveEl = card?.querySelector(".ai-agent-live");
   const toolLines = new Map(); // tool_call id → row element
   chat.scrollTop = chat.scrollHeight;
+
+  // Re-query the live container on every append. A captured reference
+  // would go stale the moment something else mutates chat.innerHTML
+  // during the stream (engine error card, smoke test card from a prior
+  // run, another sendMessage), and writes would land on a detached
+  // node — invisible to the user but consuming the rest of the trace.
+  const getLiveEl = () => document.getElementById(cardId)?.querySelector(".ai-agent-live");
 
   // Append into `.ai-agent-live` in arrival order. Consecutive reasoning
   // or token events coalesce into the same block (typing-style growth);
   // a new event type — tool call, next-turn reasoning after tools —
   // starts a fresh block underneath so the trace reads top-to-bottom.
   const appendLive = (kind, text, opts = {}) => {
+    const liveEl = getLiveEl();
     if (!liveEl) return null;
     const last = liveEl.lastElementChild;
     if (kind === "reasoning") {
@@ -437,7 +460,7 @@ async function sendAgent(connection, msg, chat) {
   };
   const finishToolLine = (id, ok, summary) => {
     const row = toolLines.get(id);
-    if (!row) return;
+    if (!row?.isConnected) return;
     row.classList.remove("working");
     row.classList.add(ok ? "ok" : "err");
     const spin = row.querySelector(".ai-tool-spin");

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -347,6 +347,7 @@ async function sendAgent(provider, msg, chat) {
   let changedList = [];
   let finalUsage = null;
   let errored = null;
+  let streamBuf = ""; // per-turn token buffer, flushed on tool call / final
 
   try {
     const token = await state.auth.currentUser.getIdToken();
@@ -369,13 +370,22 @@ async function sendAgent(provider, msg, chat) {
       throw new Error(`agent ${res.status}: ${body.slice(0, 200)}`);
     }
 
+    const flushStream = (label) => {
+      if (!streamBuf) return;
+      console.log(`· ${label}:`, streamBuf);
+      streamBuf = "";
+    };
+
     for await (const { event, data } of parseSSE(res)) {
       if (event === "reasoning") {
-        console.log("· reasoning:", (data.text || "").slice(0, 200));
+        console.log("· reasoning:", data.text || "");
       } else if (event === "token") {
-        if (textEl && data.text) {
-          // Clear between iterations: if a tool call executed after the
-          // last token burst, the next burst is a fresh turn.
+        if (!data.text) continue;
+        // Accumulate into the per-turn buffer; flushed (one console.log)
+        // when the turn ends (tool_start or final) so the console stays
+        // readable while still preserving full visibility of the stream.
+        streamBuf += data.text;
+        if (textEl) {
           if (textEl.dataset.stale === "1") {
             textEl.textContent = "";
             textEl.dataset.stale = "";
@@ -384,24 +394,26 @@ async function sendAgent(provider, msg, chat) {
           chat.scrollTop = chat.scrollHeight;
         }
       } else if (event === "tool_start") {
+        flushStream("pre-tool text");
         console.log("→ tool:", data.name, data.input);
-        // Any streamed text that preceded this tool call was inter-turn
-        // chatter — mark stale so the next token burst overwrites it.
         if (textEl && textEl.textContent) textEl.dataset.stale = "1";
         addToolLine(data.id, toolLineLabel(data.name, data.input));
       } else if (event === "tool_result") {
         console.log("← tool:", data.name, data.ok ? "ok" : "err", data.summary);
         finishToolLine(data.id, data.ok, data.summary);
       } else if (event === "final") {
+        flushStream("final text");
         finalText = data.text || "";
         changedList = data.changed || [];
         finalUsage = data.usage || null;
         console.log("← final:", { iterations: data.iterations, changed: changedList.length });
       } else if (event === "error") {
+        flushStream("pre-error text");
         errored = data.message || "agent error";
         console.error("← error:", data);
       }
     }
+    flushStream("trailing text");
 
     if (errored) throw new Error(errored);
 
@@ -419,11 +431,15 @@ async function sendAgent(provider, msg, chat) {
         try {
           const r = await apiFetch(`/games/${state.currentGameId}/files/${w.name}`);
           if (!r.ok) return;
-          const text = await r.text();
+          // The GET returns {"content": "..."} — NOT the raw file body —
+          // so we must unwrap. Previously we did r.text() which stuffed
+          // the JSON envelope into state.currentFiles, making the engine
+          // execute garbage on the next Play.
+          const { content } = await r.json();
           const idx = state.currentFiles.findIndex(c => c.name === w.name);
           const action = idx >= 0 ? "edited" : "created";
-          if (idx >= 0) state.currentFiles[idx].content = text;
-          else state.currentFiles.push({ name: w.name, content: text });
+          if (idx >= 0) state.currentFiles[idx].content = content;
+          else state.currentFiles.push({ name: w.name, content });
           changedFiles.push({ name: w.name, _action: action });
         } catch (e) {
           console.warn("re-sync failed:", w.name, e);

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -8,8 +8,11 @@ import { openAIProviders } from './settings.js';
 // Models whose server-side PROVIDERS entry has apiType=openai. Those
 // route to /chat/agent (SSE tool-use loop); anything else falls back
 // to the one-shot /chat endpoint via the legacy path in sendMessage.
-// Keep in sync with PROVIDERS in mono-api/src/index.js.
-const AGENT_MODELS = new Set([
+// The authoritative list lives in mono-api/src/index.js PROVIDERS;
+// the client fetches it from /config on boot. Hardcoded fallback is
+// used until the config arrives (first-load / offline) so the feature
+// still works if the network blip happens before we initialize.
+let AGENT_MODELS = new Set([
   "kimi-latest", "o3", "gpt-4.1",
   "gpt-5.3-codex-apimart", "gpt-5.4-apimart",
   "claude-code",
@@ -17,6 +20,23 @@ const AGENT_MODELS = new Set([
 function usesAgentPath(modelValue) {
   return AGENT_MODELS.has(modelValue);
 }
+
+// Fire-and-forget on module load — replaces AGENT_MODELS with the
+// server's source of truth. No auth required (public endpoint).
+(async function loadAgentModelsFromConfig() {
+  try {
+    const res = await fetch(`${API_URL}/config`);
+    if (!res.ok) return;
+    const data = await res.json();
+    if (Array.isArray(data.agentModels) && data.agentModels.length) {
+      AGENT_MODELS = new Set(data.agentModels);
+    }
+  } catch {
+    // Offline or network error — keep the hardcoded fallback. Any drift
+    // only matters when the server adds a NEW openai-compat model; the
+    // hardcoded list still covers the six built-ins as of this writing.
+  }
+})();
 
 // ── Card builders ──
 

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -655,8 +655,8 @@ export async function sendMessage(autoMsg) {
   if (!selectedValue.startsWith("provider:")) {
     const chatEl = document.getElementById("editor-chat");
     chatEl.innerHTML += errorCard(
-      "Register an AI provider in Settings → AI Providers, then pick it from the pill above to enable chat.",
-      "NO PROVIDER",
+      "Register a Connection in Settings → AI Assistant, then pick it from the pill above to enable chat.",
+      "NO CONNECTION",
       false,
     );
     chatEl.scrollTop = chatEl.scrollHeight;

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -110,6 +110,62 @@ function monoCard(message, files, status = "completed") {
   return html;
 }
 
+// Completed agent card with a collapsed trace footer. `trace` is an
+// ordered list of { kind: "reasoning"|"text"|"tool", ... } captured
+// during the /chat/agent SSE run; `stats` is { iterations, tools,
+// tokens } for the header summary. Trace stays collapsed by default
+// so the chat looks clean; user clicks to unfold.
+function formatTokens(n) {
+  if (!n) return "0";
+  if (n >= 1000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return String(n);
+}
+
+function monoCardAgentCompleted(message, files, trace, stats) {
+  let html = `<div class="ai-card-mono">
+    <div class="ai-card-status">MONO · completed</div>`;
+  const cleaned = cleanMessage(message);
+  if (cleaned) html += `<div class="ai-card-response">${renderMarkdown(cleaned)}</div>`;
+  if (files && files.length > 0) {
+    for (const f of files) {
+      const action = f._action || "edited";
+      const prefix = action === "created" ? "+ " : action === "deleted" ? "- " : "~ ";
+      html += `<div class="ai-card-file">${prefix}${esc(f.name)}  ·  ${action}</div>`;
+    }
+  }
+
+  if (trace && trace.length > 0) {
+    const parts = [];
+    if (stats?.iterations) parts.push(`${stats.iterations} iter`);
+    if (stats?.tools) parts.push(`${stats.tools} tool${stats.tools === 1 ? "" : "s"}`);
+    if (stats?.tokens) parts.push(`${formatTokens(stats.tokens)} tok`);
+    const summary = parts.length ? ` (${parts.join(" · ")})` : "";
+
+    let traceHtml = "";
+    for (const ev of trace) {
+      if (ev.kind === "reasoning") {
+        traceHtml += `<div class="ai-trace-reasoning">💭 ${esc(ev.text)}</div>`;
+      } else if (ev.kind === "text") {
+        traceHtml += `<div class="ai-trace-text">${esc(ev.text)}</div>`;
+      } else if (ev.kind === "tool") {
+        const label = toolLineLabel(ev.name, ev.input);
+        const cls = ev.ok === false ? "err" : ev.ok === true ? "ok" : "working";
+        const mark = ev.ok === false ? "✗" : ev.ok === true ? "✓" : "◌";
+        const tail = ev.summary ? ` — ${esc(ev.summary)}` : "";
+        traceHtml += `<div class="ai-tool-line ${cls}">`
+          + `<span class="ai-tool-spin">${mark}</span>`
+          + `<span class="ai-tool-text">${esc(label)}${tail}</span>`
+          + `</div>`;
+      }
+    }
+    html += `<button class="ai-trace-toggle" data-expanded="0">▸ Show trace${summary}</button>`;
+    html += `<div class="ai-trace" hidden>${traceHtml}</div>`;
+  }
+
+  html += `</div>`;
+  return html;
+}
+
 function monoTypingCard() {
   return `<div class="ai-card-mono working" id="mono-typing">
     <div class="ai-card-status working">MONO · working…</div>
@@ -346,8 +402,14 @@ async function sendAgent(provider, msg, chat) {
   let finalText = "";
   let changedList = [];
   let finalUsage = null;
+  let finalIterations = 0;
   let errored = null;
   let streamBuf = ""; // per-turn token buffer, flushed on tool call / final
+  // Parallel data log of every SSE event — survives the DOM swap so the
+  // completed card can render a collapsed trace of reasoning / mid-turn
+  // text / tool calls for user inspection.
+  const trace = [];
+  const traceToolById = new Map();
 
   try {
     const token = await state.auth.currentUser.getIdToken();
@@ -370,15 +432,19 @@ async function sendAgent(provider, msg, chat) {
       throw new Error(`agent ${res.status}: ${body.slice(0, 200)}`);
     }
 
-    const flushStream = (label) => {
+    const flushStream = (label, intoTrace) => {
       if (!streamBuf) return;
       console.log(`· ${label}:`, streamBuf);
+      // Only inter-turn chatter (pre-tool text) is worth preserving in
+      // the trace; the final reply is already shown above it.
+      if (intoTrace) trace.push({ kind: "text", text: streamBuf });
       streamBuf = "";
     };
 
     for await (const { event, data } of parseSSE(res)) {
       if (event === "reasoning") {
         console.log("· reasoning:", data.text || "");
+        if (data.text) trace.push({ kind: "reasoning", text: data.text });
       } else if (event === "token") {
         if (!data.text) continue;
         // Accumulate into the per-turn buffer; flushed (one console.log)
@@ -394,26 +460,32 @@ async function sendAgent(provider, msg, chat) {
           chat.scrollTop = chat.scrollHeight;
         }
       } else if (event === "tool_start") {
-        flushStream("pre-tool text");
+        flushStream("pre-tool text", true);
         console.log("→ tool:", data.name, data.input);
         if (textEl && textEl.textContent) textEl.dataset.stale = "1";
         addToolLine(data.id, toolLineLabel(data.name, data.input));
+        const entry = { kind: "tool", id: data.id, name: data.name, input: data.input, ok: null, summary: null };
+        trace.push(entry);
+        traceToolById.set(data.id, entry);
       } else if (event === "tool_result") {
         console.log("← tool:", data.name, data.ok ? "ok" : "err", data.summary);
         finishToolLine(data.id, data.ok, data.summary);
+        const entry = traceToolById.get(data.id);
+        if (entry) { entry.ok = !!data.ok; entry.summary = data.summary || ""; }
       } else if (event === "final") {
-        flushStream("final text");
+        flushStream("final text", false);
         finalText = data.text || "";
         changedList = data.changed || [];
         finalUsage = data.usage || null;
+        finalIterations = data.iterations || 0;
         console.log("← final:", { iterations: data.iterations, changed: changedList.length });
       } else if (event === "error") {
-        flushStream("pre-error text");
+        flushStream("pre-error text", true);
         errored = data.message || "agent error";
         console.error("← error:", data);
       }
     }
-    flushStream("trailing text");
+    flushStream("trailing text", false);
 
     if (errored) throw new Error(errored);
 
@@ -458,7 +530,12 @@ async function sendAgent(provider, msg, chat) {
     state.chatHistory.push({ role: "assistant", content: finalText });
     saveChatHistory();
 
-    const replacement = monoCard(finalText, changedFiles, "completed");
+    const stats = {
+      iterations: finalIterations,
+      tools: trace.filter(t => t.kind === "tool").length,
+      tokens: finalUsage?.total_tokens || 0,
+    };
+    const replacement = monoCardAgentCompleted(finalText, changedFiles, trace, stats);
     if (card) card.outerHTML = replacement;
     console.groupEnd();
 
@@ -676,6 +753,24 @@ export function initEditorAI() {
       const errText = card?.querySelector(".ai-card-response")?.textContent || "";
       const label = card?.querySelector(".ai-card-status")?.textContent || "ERROR";
       if (errText) showFixConfirm(errText, label);
+      return;
+    }
+    // Agent trace toggle → expand/collapse the reasoning + tool log.
+    const traceBtn = e.target.closest(".ai-trace-toggle");
+    if (traceBtn) {
+      const card = traceBtn.closest(".ai-card-mono");
+      const panel = card?.querySelector(".ai-trace");
+      if (!panel) return;
+      const expanded = traceBtn.dataset.expanded === "1";
+      if (expanded) {
+        panel.hidden = true;
+        traceBtn.dataset.expanded = "0";
+        traceBtn.textContent = traceBtn.textContent.replace(/^▾/, "▸").replace("Hide trace", "Show trace");
+      } else {
+        panel.hidden = false;
+        traceBtn.dataset.expanded = "1";
+        traceBtn.textContent = traceBtn.textContent.replace(/^▸/, "▾").replace("Show trace", "Hide trace");
+      }
       return;
     }
   });

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -5,36 +5,41 @@ import { apiFetch, saveChatHistory } from './api.js';
 import { runHeadlessTest, defaultSmokeScenario } from './editor-play.js';
 import { openAIProviders } from './settings.js';
 
-// Models whose server-side PROVIDERS entry has apiType=openai. Those
-// route to /chat/agent (SSE tool-use loop); anything else falls back
-// to the one-shot /chat endpoint via the legacy path in sendMessage.
-// The authoritative list lives in mono-api/src/index.js PROVIDERS;
-// the client fetches it from /config on boot. Hardcoded fallback is
-// used until the config arrives (first-load / offline) so the feature
-// still works if the network blip happens before we initialize.
-let AGENT_MODELS = new Set([
-  "kimi-latest", "o3", "gpt-4.1",
-  "gpt-5.3-codex-apimart", "gpt-5.4-apimart",
-  "claude-code",
+// Provider catalog from mono-api /config — { id, protocol, ... }. The
+// client uses it to decide whether a Connection routes to /chat/agent
+// (openai-protocol tool-use loop) or /chat (one-shot). Fetched fire-
+// and-forget at module load; until it arrives the set below carries
+// the built-in openai-protocol providers so first-boot doesn't lose
+// agent routing on a slow network.
+let AGENT_PROTOCOLS = new Set(["openai"]);
+let PROVIDER_PROTOCOL = new Map([
+  ["openai",    "openai"],
+  ["moonshot",  "openai"],
+  ["apimart",   "openai"],
+  ["custom",    "openai"],
+  ["anthropic", "anthropic"],
+  ["google",    "gemini"],
 ]);
-function usesAgentPath(modelValue) {
-  return AGENT_MODELS.has(modelValue);
+function usesAgentPath(connection) {
+  const proto = PROVIDER_PROTOCOL.get(connection?.provider);
+  return !!proto && AGENT_PROTOCOLS.has(proto);
 }
 
-// Fire-and-forget on module load — replaces AGENT_MODELS with the
-// server's source of truth. No auth required (public endpoint).
-(async function loadAgentModelsFromConfig() {
+(async function loadCatalogFromConfig() {
   try {
     const res = await fetch(`${API_URL}/config`);
     if (!res.ok) return;
     const data = await res.json();
-    if (Array.isArray(data.agentModels) && data.agentModels.length) {
-      AGENT_MODELS = new Set(data.agentModels);
+    if (Array.isArray(data.providers)) {
+      const map = new Map();
+      for (const p of data.providers) map.set(p.id, p.protocol);
+      PROVIDER_PROTOCOL = map;
+    }
+    if (Array.isArray(data.agentProtocols)) {
+      AGENT_PROTOCOLS = new Set(data.agentProtocols);
     }
   } catch {
-    // Offline or network error — keep the hardcoded fallback. Any drift
-    // only matters when the server adds a NEW openai-compat model; the
-    // hardcoded list still covers the six built-ins as of this writing.
+    // Offline — keep the hardcoded fallback.
   }
 })();
 
@@ -375,12 +380,12 @@ async function* parseSSE(response) {
   }
 }
 
-async function sendAgent(provider, msg, chat) {
-  const model = provider.model;
+async function sendAgent(connection, msg, chat) {
+  const providerId = connection.provider;
+  const model = connection.model;
   const byok = {
-    key: provider.key,
-    url: provider.url || undefined,
-    modelName: provider.modelName || undefined,
+    apiKey: connection.apiKey,
+    baseUrl: connection.baseUrl || undefined,
   };
 
   const cardId = `mono-agent-${Date.now()}`;
@@ -442,7 +447,7 @@ async function sendAgent(provider, msg, chat) {
   };
 
   console.group("[MONO Agent]");
-  console.log("→ model:", model, byok.modelName ? `(override: ${byok.modelName})` : "");
+  console.log("→", providerId, "·", model, byok.baseUrl ? `@ ${byok.baseUrl}` : "");
   console.log("→ message:", msg);
 
   let finalText = "";
@@ -471,6 +476,7 @@ async function sendAgent(provider, msg, chat) {
         gameId: state.currentGameId,
         message: msg,
         history: state.chatHistory.slice(0, -1),
+        provider: providerId,
         model,
         byok,
       }),
@@ -672,26 +678,25 @@ export async function sendMessage(autoMsg) {
   state.chatHistory.push({ role: "user", content: msg });
 
   try {
-    const provider = state.aiProviders.find(p => p.id === selectedValue.slice(9));
-    if (!provider) throw new Error("Selected provider no longer exists — pick another one from the pill above.");
+    const connection = state.aiConnections.find(p => p.id === selectedValue.slice(9));
+    if (!connection) throw new Error("Selected connection no longer exists — pick another one from the pill above.");
 
-    // OpenAI-compat providers run the full agentic tool-use loop on the
-    // server, streamed over SSE. Everything else falls back to one-shot
-    // /chat (which still handles anthropic / gemini / responses apiTypes).
-    if (usesAgentPath(provider.model)) {
-      await sendAgent(provider, msg, chat);
+    // openai-protocol connections run the server-side agent tool-use loop
+    // over SSE; anthropic / gemini fall back to one-shot /chat.
+    if (usesAgentPath(connection)) {
+      await sendAgent(connection, msg, chat);
       return;
     }
 
-    const model = provider.model;
+    const providerId = connection.provider;
+    const model = connection.model;
     const byok = {
-      key: provider.key,
-      url: provider.url || undefined,
-      modelName: provider.modelName || undefined,
+      apiKey: connection.apiKey,
+      baseUrl: connection.baseUrl || undefined,
     };
 
     console.group("[MONO Chat]");
-    console.log("→ model:", model, byok.modelName ? `(override: ${byok.modelName})` : "");
+    console.log("→", providerId, "·", model, byok.baseUrl ? `@ ${byok.baseUrl}` : "");
     console.log("→ message:", msg);
     console.log("→ files:", state.currentFiles.map(f => f.name));
     console.groupEnd();
@@ -704,6 +709,7 @@ export async function sendMessage(autoMsg) {
         message: msg,
         files: state.currentFiles,
         history: state.chatHistory.slice(0, -1),
+        provider: providerId,
         model,
         byok,
       }),

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -2,7 +2,7 @@
 
 import { state, esc, chatTime, API_URL } from './state.js';
 import { apiFetch, saveChatHistory } from './api.js';
-import { runHeadlessTest } from './editor-play.js';
+import { runHeadlessTest, defaultSmokeScenario } from './editor-play.js';
 import { openAIProviders } from './settings.js';
 
 // Models whose server-side PROVIDERS entry has apiType=openai. Those
@@ -461,6 +461,34 @@ async function sendAgent(provider, msg, chat) {
     const replacement = monoCard(finalText, changedFiles, "completed");
     if (card) card.outerHTML = replacement;
     console.groupEnd();
+
+    // Smoke test: if the agent edited any .lua file, run the headless
+    // worker with a scripted tap scenario. Catches runtime errors that
+    // the static write_file lint can't (nil arithmetic, wrong touch_pos
+    // semantics, scene callbacks throwing on input). Always on for the
+    // agent path so bad writes surface in seconds instead of next Play.
+    const luaChanged = changedFiles.some(f => f.name.endsWith(".lua"));
+    if (luaChanged) {
+      const scenario = defaultSmokeScenario();
+      const testCardId = `smoke-${Date.now()}`;
+      chat.innerHTML += `<div class="ai-card-mono working" id="${testCardId}">
+        <div class="ai-card-status working">MONO · running smoke test…</div>
+      </div>`;
+      chat.scrollTop = chat.scrollHeight;
+      const result = await runHeadlessTest(state.currentFiles, scenario);
+      const testCard = document.getElementById(testCardId);
+      if (result.success) {
+        if (testCard) testCard.outerHTML = `<div class="ai-card-mono">
+          <div class="ai-card-status">MONO · smoke test</div>
+          <div class="ai-card-response" style="color:#7bcf7b">✓ booted + tap scenario cleared (${scenario.frames} frames)</div>
+        </div>`;
+      } else {
+        const errs = (result.errors || ["unknown error"]).join("\n");
+        console.error("[smoke test] failed:", errs);
+        if (testCard) testCard.outerHTML = errorCard(errs, "SMOKE TEST FAILED");
+      }
+      chat.scrollTop = chat.scrollHeight;
+    }
   } catch (e) {
     console.error("agent error:", e);
     console.groupEnd();

--- a/dev/js/editor-play.js
+++ b/dev/js/editor-play.js
@@ -5,14 +5,36 @@ import { showEngineError, clearEngineError } from './editor-ai.js';
 
 // ── Headless test (used by AI tab too) ──
 
-export function runHeadlessTest(files, frames = 30) {
+// Back-compat: runHeadlessTest(files, 60) still works; new callers pass
+// { frames, inputScript } to simulate taps / button presses and exercise
+// code paths that a pure idle loop would miss (e.g. touch_start polling).
+export function runHeadlessTest(files, opts = {}) {
+  const options = typeof opts === "number" ? { frames: opts } : (opts || {});
+  const { frames = 30, inputScript = null } = options;
   return new Promise((resolve) => {
     const w = new Worker("/dev/test-worker.js?v=" + Date.now());
     const timeout = setTimeout(() => { w.terminate(); resolve({ success: false, errors: ["Test timed out"] }); }, 15000);
     w.onmessage = (e) => { clearTimeout(timeout); w.terminate(); resolve(e.data); };
     w.onerror = (e) => { clearTimeout(timeout); w.terminate(); resolve({ success: false, errors: [e.message] }); };
-    w.postMessage({ files, frames });
+    w.postMessage({ files, frames, inputScript });
   });
+}
+
+// Default smoke-test scenario for the agent path: boots + runs a brief
+// idle stretch, then simulates a single tap at screen center with a
+// touch_start / held / touch_end sequence. Catches most "works until the
+// player touches something" runtime errors (missing nil guards, wrong
+// touch_pos semantics, scene callbacks that throw on input).
+export function defaultSmokeScenario() {
+  return {
+    frames: 40,
+    inputScript: [
+      { frame: 10, touchStart: true, touches: [{ x: 80, y: 60 }] },
+      { frame: 11, touches: [{ x: 80, y: 60 }] },
+      { frame: 12, touches: [{ x: 80, y: 60 }] },
+      { frame: 13, touchEnd: true, touches: [{ x: 80, y: 60 }] },
+    ],
+  };
 }
 
 // ── Console log ──

--- a/dev/js/editor.js
+++ b/dev/js/editor.js
@@ -34,7 +34,10 @@ const TAB_TOPBAR_BUTTONS = {
   },
   ai: (nav) => {
     // Provider pill — shows current BYOK provider alias, or a "No provider"
-    // prompt that jumps to AI Providers settings when clicked.
+    // prompt that jumps to AI Providers settings when clicked. Native
+    // <select>.click() can't be programmatically opened in most browsers,
+    // so we paint our own menu panel anchored under the pill and keep the
+    // hidden <select> as the value store + change-event source.
     const sel = document.getElementById("model-select");
     const hasProviders = !!(sel && sel.options.length > 0);
     const label = hasProviders
@@ -46,27 +49,86 @@ const TAB_TOPBAR_BUTTONS = {
         <span class="pill-label">${label}</span>
         <span class="pill-chev"><svg viewBox="0 0 24 24" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></span>
       </button>`;
-    nav.querySelector("#btn-provider-pill")?.addEventListener("click", () => {
-      // No providers → send user to AI Providers settings instead of
-      // opening an empty <select>.
+
+    const pill = nav.querySelector("#btn-provider-pill");
+    pill?.addEventListener("click", () => {
+      // Clicking the pill while the menu is open → close (toggle).
+      const existing = document.getElementById("provider-menu-pop");
+      if (existing) { existing.remove(); return; }
+
+      // No providers registered → jump straight to settings.
       if (!sel || sel.options.length === 0) {
         openAIProviders();
         return;
       }
-      sel.style.display = "block";
-      sel.style.position = "fixed";
-      sel.style.opacity = "0";
-      sel.focus();
-      sel.click();
-      const hide = () => {
-        sel.style.display = "none";
-        const newLabel = sel.options[sel.selectedIndex]?.textContent || "Model";
-        const pillLabel = nav.querySelector(".pill-label");
-        if (pillLabel) pillLabel.textContent = newLabel;
-        sel.removeEventListener("blur", hide);
+
+      const menu = document.createElement("div");
+      menu.id = "provider-menu-pop";
+      menu.className = "provider-menu-pop";
+
+      // One row per <option>. Clicking commits the selection and
+      // dispatches a change event so the saved-model listener in
+      // initEditor() persists it to localStorage.
+      for (let i = 0; i < sel.options.length; i++) {
+        const opt = sel.options[i];
+        const row = document.createElement("button");
+        row.type = "button";
+        row.className = "provider-menu-row" + (i === sel.selectedIndex ? " active" : "");
+        row.innerHTML = `
+          <span class="provider-menu-dot">${i === sel.selectedIndex ? "●" : ""}</span>
+          <span class="provider-menu-name">${esc(opt.textContent)}</span>`;
+        row.addEventListener("click", (e) => {
+          e.stopPropagation();
+          sel.value = opt.value;
+          sel.dispatchEvent(new Event("change", { bubbles: true }));
+          const pillLabel = nav.querySelector(".pill-label");
+          if (pillLabel) pillLabel.textContent = opt.textContent;
+          menu.remove();
+        });
+        menu.appendChild(row);
+      }
+
+      // Footer link to the AI Providers settings view.
+      const sep = document.createElement("div");
+      sep.className = "provider-menu-sep";
+      menu.appendChild(sep);
+
+      const manage = document.createElement("button");
+      manage.type = "button";
+      manage.className = "provider-menu-row manage";
+      manage.textContent = "Manage providers…";
+      manage.addEventListener("click", (e) => {
+        e.stopPropagation();
+        menu.remove();
+        openAIProviders();
+      });
+      menu.appendChild(manage);
+
+      // Anchor under the pill, right-aligned.
+      const rect = pill.getBoundingClientRect();
+      menu.style.top = `${rect.bottom + 4}px`;
+      menu.style.right = `${Math.max(8, window.innerWidth - rect.right)}px`;
+      document.body.appendChild(menu);
+
+      // Click-outside + Escape to close. Added on the next tick so the
+      // current click that opened the menu doesn't immediately close it.
+      const onDocClick = (e) => {
+        if (!menu.contains(e.target) && !pill.contains(e.target)) {
+          cleanup();
+        }
       };
-      sel.addEventListener("change", hide, { once: true });
-      sel.addEventListener("blur", hide, { once: true });
+      const onKey = (e) => {
+        if (e.key === "Escape") { e.preventDefault(); cleanup(); }
+      };
+      function cleanup() {
+        menu.remove();
+        document.removeEventListener("click", onDocClick, true);
+        document.removeEventListener("keydown", onKey, true);
+      }
+      setTimeout(() => {
+        document.addEventListener("click", onDocClick, true);
+        document.addEventListener("keydown", onKey, true);
+      }, 0);
     });
   },
   play: (nav) => {

--- a/dev/js/editor.js
+++ b/dev/js/editor.js
@@ -33,35 +33,40 @@ const TAB_TOPBAR_BUTTONS = {
     if (initTopbarHandlers) initTopbarHandlers();
   },
   ai: (nav) => {
-    // Provider pill — shows current model name
+    // Provider pill — shows current BYOK provider alias, or a "No provider"
+    // prompt that jumps to AI Providers settings when clicked.
     const sel = document.getElementById("model-select");
-    const label = sel ? sel.options[sel.selectedIndex]?.textContent || "Model" : "Model";
+    const hasProviders = !!(sel && sel.options.length > 0);
+    const label = hasProviders
+      ? (sel.options[sel.selectedIndex]?.textContent || "Model")
+      : "No provider";
     nav.innerHTML = `
-      <button class="ai-provider-pill" id="btn-provider-pill">
+      <button class="ai-provider-pill${hasProviders ? '' : ' empty'}" id="btn-provider-pill">
         <span class="pill-icon"><svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor"><path d="M12 2L9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61z"/></svg></span>
         <span class="pill-label">${label}</span>
         <span class="pill-chev"><svg viewBox="0 0 24 24" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></span>
       </button>`;
-    // Click pill → open hidden <select>
     nav.querySelector("#btn-provider-pill")?.addEventListener("click", () => {
-      const select = document.getElementById("model-select");
-      if (select) {
-        select.style.display = "block";
-        select.style.position = "fixed";
-        select.style.opacity = "0";
-        select.focus();
-        select.click();
-        // On change/blur, re-hide and update pill label
-        const hide = () => {
-          select.style.display = "none";
-          const newLabel = select.options[select.selectedIndex]?.textContent || "Model";
-          const pillLabel = nav.querySelector(".pill-label");
-          if (pillLabel) pillLabel.textContent = newLabel;
-          select.removeEventListener("blur", hide);
-        };
-        select.addEventListener("change", hide, { once: true });
-        select.addEventListener("blur", hide, { once: true });
+      // No providers → send user to AI Providers settings instead of
+      // opening an empty <select>.
+      if (!sel || sel.options.length === 0) {
+        openAIProviders();
+        return;
       }
+      sel.style.display = "block";
+      sel.style.position = "fixed";
+      sel.style.opacity = "0";
+      sel.focus();
+      sel.click();
+      const hide = () => {
+        sel.style.display = "none";
+        const newLabel = sel.options[sel.selectedIndex]?.textContent || "Model";
+        const pillLabel = nav.querySelector(".pill-label");
+        if (pillLabel) pillLabel.textContent = newLabel;
+        sel.removeEventListener("blur", hide);
+      };
+      sel.addEventListener("change", hide, { once: true });
+      sel.addEventListener("blur", hide, { once: true });
     });
   },
   play: (nav) => {

--- a/dev/js/editor.js
+++ b/dev/js/editor.js
@@ -232,12 +232,12 @@ export async function openEditor(gameId, title, desc) {
 
   // Load AI providers if needed
   const vaultPp = getVaultPp();
-  if (state.aiProviders.length === 0 && vaultPp) {
+  if (state.aiConnections.length === 0 && vaultPp) {
     try {
       const uid = state.auth.currentUser.uid;
       const snap = await getDoc(doc(state.db, "users", uid, "settings", "ai"));
       if (snap.exists() && snap.data().encrypted) {
-        state.aiProviders = await decryptData(vaultPp, snap.data().encrypted);
+        state.aiConnections = await decryptData(vaultPp, snap.data().encrypted);
         updateModelSelector();
       }
     } catch {}
@@ -343,10 +343,10 @@ export function initEditor() {
     const val = e.target.value;
     localStorage.setItem("mono_model", val);
     if (val.startsWith("provider:")) {
-      const noUserDefault = !state.aiProviders.some(p => p.isDefault);
+      const noUserDefault = !state.aiConnections.some(p => p.isDefault);
       if (noUserDefault) {
         const pid = val.slice(9);
-        state.aiProviders.forEach(p => p.isDefault = (p.id === pid));
+        state.aiConnections.forEach(p => p.isDefault = (p.id === pid));
         saveProviders();
       }
     }

--- a/dev/js/settings.js
+++ b/dev/js/settings.js
@@ -260,6 +260,7 @@ function editProvider(idx) {
   document.getElementById("apf-default-toggle").className = p.isDefault ? "apf-toggle on" : "apf-toggle";
   document.getElementById("apf-test-result").className = "apf-test-result";
   document.getElementById("btn-apf-delete").className = "apf-delete-btn show";
+  document.getElementById("btn-apf-duplicate").className = "apf-duplicate-btn show";
   showView("add-provider");
 }
 
@@ -456,6 +457,7 @@ export function initSettings() {
     document.getElementById("apf-default-toggle").className = "apf-toggle";
     document.getElementById("apf-test-result").className = "apf-test-result";
     document.getElementById("btn-apf-delete").className = "apf-delete-btn";
+    document.getElementById("btn-apf-duplicate").className = "apf-duplicate-btn";
     showView("add-provider");
   });
 
@@ -495,6 +497,24 @@ export function initSettings() {
   document.getElementById("btn-apf-delete").addEventListener("click", async () => {
     if (!confirm("Delete this provider?")) return;
     state.aiProviders.splice(state.editingProviderIdx, 1);
+    await saveProviders();
+    renderProviderList();
+    showView("ai-providers");
+  });
+
+  // Duplicate provider — clones the currently edited entry with a fresh
+  // id, " (copy)" suffix on the alias, and isDefault forced off. Stays
+  // on the list so the user can tweak either copy.
+  document.getElementById("btn-apf-duplicate").addEventListener("click", async () => {
+    if (state.editingProviderIdx < 0) return;
+    const src = state.aiProviders[state.editingProviderIdx];
+    const copy = {
+      ...src,
+      id: crypto.randomUUID(),
+      alias: `${src.alias} (copy)`,
+      isDefault: false,
+    };
+    state.aiProviders.push(copy);
     await saveProviders();
     renderProviderList();
     showView("ai-providers");

--- a/dev/js/settings.js
+++ b/dev/js/settings.js
@@ -548,4 +548,56 @@ export function initSettings() {
     }
     btn.textContent = "⚡ Test Connection";
   });
+
+  // Fetch model list — calls mono-api /models with the BYOK url+key,
+  // populates the Custom Model Name datalist for autocomplete.
+  document.getElementById("btn-apf-fetch-models").addEventListener("click", async () => {
+    const model = document.getElementById("apf-model").value;
+    const key = document.getElementById("apf-key").value.trim();
+    const url = document.getElementById("apf-url").value.trim();
+    const status = document.getElementById("apf-fetch-status");
+    const btn = document.getElementById("btn-apf-fetch-models");
+    if (!key) { status.textContent = "Enter an API key first"; status.className = "apf-fetch-status warn"; return; }
+
+    btn.disabled = true;
+    btn.textContent = "Fetching…";
+    status.textContent = "";
+    status.className = "apf-fetch-status";
+
+    try {
+      const res = await apiFetch("/models", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: url || undefined, key, model }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || data.detail || `HTTP ${res.status}`);
+      const list = document.getElementById("apf-model-name-list");
+      list.innerHTML = "";
+      const models = data.models || [];
+      // Sort: reasoning-capable first, then vision, then alpha.
+      models.sort((a, b) => {
+        if (a.reasoning !== b.reasoning) return a.reasoning ? -1 : 1;
+        if (a.vision !== b.vision) return a.vision ? -1 : 1;
+        return a.id.localeCompare(b.id);
+      });
+      for (const m of models) {
+        const opt = document.createElement("option");
+        opt.value = m.id;
+        const tags = [];
+        if (m.reasoning) tags.push("reasoning");
+        if (m.vision) tags.push("vision");
+        if (m.context) tags.push(`${Math.round(m.context / 1024)}K ctx`);
+        if (tags.length) opt.label = `${m.id} — ${tags.join(", ")}`;
+        list.appendChild(opt);
+      }
+      status.textContent = `✓ ${models.length} models — type or click the field to browse`;
+      status.className = "apf-fetch-status success";
+    } catch (e) {
+      status.textContent = `✗ ${e.message}`;
+      status.className = "apf-fetch-status error";
+    }
+    btn.disabled = false;
+    btn.textContent = "🔍 Fetch";
+  });
 }

--- a/dev/js/settings.js
+++ b/dev/js/settings.js
@@ -145,16 +145,24 @@ function onProviderListClick(e) {
 export function updateModelSelector() {
   const sel = document.getElementById("model-select");
   if (!sel) return;
-  sel.querySelectorAll('option[data-custom]').forEach(o => o.remove());
+  // Chat is BYOK-only: rebuild the full list from state.aiProviders so
+  // there is no "mono default" option lingering in the DOM.
+  sel.innerHTML = "";
   for (const p of state.aiProviders) {
     const opt = document.createElement("option");
     opt.value = `provider:${p.id}`;
     opt.textContent = p.alias;
-    opt.dataset.custom = "1";
-    sel.prepend(opt);
+    sel.appendChild(opt);
   }
   const def = state.aiProviders.find(p => p.isDefault);
   if (def) sel.value = `provider:${def.id}`;
+  // Refresh the provider pill label if the AI tab's topbar is mounted.
+  const pillLabel = document.querySelector("#btn-provider-pill .pill-label");
+  if (pillLabel) {
+    pillLabel.textContent = sel.options.length === 0
+      ? "No provider"
+      : (sel.options[sel.selectedIndex]?.textContent || "Model");
+  }
 }
 
 // ── AI Providers navigation ──

--- a/dev/js/settings.js
+++ b/dev/js/settings.js
@@ -256,6 +256,7 @@ function editProvider(idx) {
   document.getElementById("apf-model").value = p.model;
   document.getElementById("apf-key").value = p.key;
   document.getElementById("apf-url").value = p.url || "";
+  document.getElementById("apf-model-name").value = p.modelName || "";
   document.getElementById("apf-default-toggle").className = p.isDefault ? "apf-toggle on" : "apf-toggle";
   document.getElementById("apf-test-result").className = "apf-test-result";
   document.getElementById("btn-apf-delete").className = "apf-delete-btn show";
@@ -451,6 +452,7 @@ export function initSettings() {
     document.getElementById("apf-model").value = "gpt-5.3-codex";
     document.getElementById("apf-key").value = "";
     document.getElementById("apf-url").value = "";
+    document.getElementById("apf-model-name").value = "";
     document.getElementById("apf-default-toggle").className = "apf-toggle";
     document.getElementById("apf-test-result").className = "apf-test-result";
     document.getElementById("btn-apf-delete").className = "apf-delete-btn";
@@ -468,6 +470,7 @@ export function initSettings() {
     const model = document.getElementById("apf-model").value;
     const key = document.getElementById("apf-key").value.trim();
     const url = document.getElementById("apf-url").value.trim();
+    const modelName = document.getElementById("apf-model-name").value.trim();
     const isDefault = document.getElementById("apf-default-toggle").classList.contains("on");
     if (!alias || !key) { alert("Alias and API Key are required"); return; }
 
@@ -475,9 +478,12 @@ export function initSettings() {
 
     if (state.editingProviderIdx >= 0) {
       const p = state.aiProviders[state.editingProviderIdx];
-      p.alias = alias; p.model = model; p.key = key; p.url = url; p.isDefault = isDefault;
+      p.alias = alias; p.model = model; p.key = key; p.url = url;
+      p.modelName = modelName; p.isDefault = isDefault;
     } else {
-      state.aiProviders.push({ id: crypto.randomUUID(), alias, model, key, url, isDefault });
+      state.aiProviders.push({
+        id: crypto.randomUUID(), alias, model, key, url, modelName, isDefault,
+      });
     }
 
     await saveProviders();
@@ -499,6 +505,7 @@ export function initSettings() {
     const model = document.getElementById("apf-model").value;
     const key = document.getElementById("apf-key").value.trim();
     const url = document.getElementById("apf-url").value.trim();
+    const modelName = document.getElementById("apf-model-name").value.trim();
     if (!key) { alert("Enter an API key first"); return; }
 
     const btn = document.getElementById("btn-apf-test");
@@ -516,7 +523,11 @@ export function initSettings() {
           files: [],
           history: [],
           model,
-          byok: { key, url: url || undefined },
+          byok: {
+            key,
+            url: url || undefined,
+            modelName: modelName || undefined,
+          },
         }),
       });
       const elapsed = Date.now() - start;

--- a/dev/js/settings.js
+++ b/dev/js/settings.js
@@ -1,6 +1,6 @@
 // ── AI Provider Vault + Dev Settings ──
 
-import { state, esc, showView } from './state.js';
+import { state, esc, showView, API_URL } from './state.js';
 import { apiFetch } from './api.js';
 import {
   doc,
@@ -99,12 +99,25 @@ export async function loadProviders() {
     const uid = state.auth.currentUser.uid;
     const snap = await getDoc(doc(state.db, "users", uid, "settings", "ai"));
     if (snap.exists() && snap.data().encrypted) {
-      state.aiProviders = await decryptData(pp, snap.data().encrypted);
+      const loaded = await decryptData(pp, snap.data().encrypted);
+      // Detect legacy shape (pre-PROVIDER_CATALOG): old entries carry
+      // `key` / `url` / `modelName` and a flat preset `model` key, with
+      // no `provider` field. Wipe them — user will re-add under the new
+      // Provider × Model structure. Banner is shown by the AI settings
+      // view so they know why.
+      const isLegacy = Array.isArray(loaded) && loaded.some(c => c && !c.provider && (c.key || c.url || c.modelName));
+      if (isLegacy) {
+        state.aiConnections = [];
+        state.connectionsWereReset = true;
+        await saveProviders();
+      } else {
+        state.aiConnections = Array.isArray(loaded) ? loaded : [];
+      }
     } else {
-      state.aiProviders = [];
+      state.aiConnections = [];
     }
   } catch {
-    state.aiProviders = [];
+    state.aiConnections = [];
   }
   renderProviderList();
 }
@@ -112,22 +125,28 @@ export async function loadProviders() {
 export async function saveProviders() {
   const pp = getVaultPp() || document.getElementById("aip-passphrase").value;
   if (!pp) { alert("Set a vault passphrase first"); return; }
-  const encrypted = await encryptData(pp, state.aiProviders);
+  const encrypted = await encryptData(pp, state.aiConnections);
   const uid = state.auth.currentUser.uid;
   await setDoc(doc(state.db, "users", uid, "settings", "ai"), { encrypted });
 }
 
 function renderProviderList() {
   const list = document.getElementById("aip-list");
-  if (state.aiProviders.length === 0) {
-    list.innerHTML = '<div style="color:#555;font-size:12px;text-align:center;padding:16px">No providers added yet</div>';
+  // One-shot banner when loadProviders() wiped a legacy-shape vault.
+  // Cleared on the user's next Add so the reset notice doesn't follow
+  // them around the app forever.
+  const banner = state.connectionsWereReset
+    ? `<div class="aip-reset-banner">AI connections were reset — the vault format changed. Please add your connections again.</div>`
+    : "";
+  if (state.aiConnections.length === 0) {
+    list.innerHTML = banner + '<div style="color:#555;font-size:12px;text-align:center;padding:16px">No connections added yet</div>';
     return;
   }
-  list.innerHTML = state.aiProviders.map((p, i) => `
+  list.innerHTML = banner + state.aiConnections.map((p, i) => `
     <div class="aip-provider-card" data-idx="${i}">
       <div>
         <div class="aip-provider-name">${esc(p.alias)}</div>
-        <div class="aip-provider-model">${esc(p.model)}</div>
+        <div class="aip-provider-model">${esc(p.provider || "")} · ${esc(p.model || "")}</div>
       </div>
       ${p.isDefault ? '<span class="aip-provider-badge">DEFAULT</span>' : '<span style="color:#555;font-size:14px">›</span>'}
     </div>
@@ -145,16 +164,16 @@ function onProviderListClick(e) {
 export function updateModelSelector() {
   const sel = document.getElementById("model-select");
   if (!sel) return;
-  // Chat is BYOK-only: rebuild the full list from state.aiProviders so
+  // Chat is BYOK-only: rebuild the full list from state.aiConnections so
   // there is no "mono default" option lingering in the DOM.
   sel.innerHTML = "";
-  for (const p of state.aiProviders) {
+  for (const p of state.aiConnections) {
     const opt = document.createElement("option");
     opt.value = `provider:${p.id}`;
     opt.textContent = p.alias;
     sel.appendChild(opt);
   }
-  const def = state.aiProviders.find(p => p.isDefault);
+  const def = state.aiConnections.find(p => p.isDefault);
   if (def) sel.value = `provider:${def.id}`;
   // Refresh the provider pill label if the AI tab's topbar is mounted.
   const pillLabel = document.querySelector("#btn-provider-pill .pill-label");
@@ -231,7 +250,7 @@ export async function openAIProviders() {
   if (getVaultPp()) {
     await loadProviders();
   } else {
-    state.aiProviders = [];
+    state.aiConnections = [];
     renderProviderList();
   }
   showView("ai-providers");
@@ -246,18 +265,69 @@ function evaluateStrength(val) {
   return Math.min(score, 3);
 }
 
-// ── Add/Edit Provider ──
+// ── Add/Edit Connection ──
+
+// Public catalog from /config. Populated once on init; each provider:
+// { id, label, protocol, baseUrl, modelsPath, requiresBaseUrl }.
+let PROVIDER_CATALOG_CACHE = [];
+
+async function loadProviderCatalog() {
+  try {
+    const res = await fetch(`${API_URL}/config`);
+    if (!res.ok) return;
+    const data = await res.json();
+    if (Array.isArray(data.providers)) {
+      PROVIDER_CATALOG_CACHE = data.providers;
+      renderProviderDropdown();
+    }
+  } catch { /* offline is fine, just can't add */ }
+}
+
+function renderProviderDropdown() {
+  const sel = document.getElementById("apf-provider");
+  if (!sel) return;
+  sel.innerHTML = PROVIDER_CATALOG_CACHE
+    .map(p => `<option value="${esc(p.id)}">${esc(p.label)}</option>`)
+    .join("");
+}
+
+// Show / hide the Base URL field based on provider.requiresBaseUrl.
+function applyProviderSelection() {
+  const providerId = document.getElementById("apf-provider").value;
+  const p = PROVIDER_CATALOG_CACHE.find(x => x.id === providerId);
+  const field = document.getElementById("apf-base-url-field");
+  const hint = document.getElementById("apf-base-url-hint");
+  if (!p) return;
+  if (p.requiresBaseUrl) {
+    field.style.display = "";
+    hint.textContent = "Required — your relay's base URL";
+  } else {
+    field.style.display = "";
+    hint.textContent = `Optional — default ${p.baseUrl || ""}`;
+  }
+  // Clear model list — it's provider-specific.
+  document.getElementById("apf-model-select").innerHTML = '<option value="">— Fetch models to populate —</option>';
+  document.getElementById("apf-fetch-status").textContent = "";
+}
 
 function editProvider(idx) {
-  state.editingProviderIdx = idx;
-  const p = state.aiProviders[idx];
-  document.getElementById("apf-title").textContent = "Edit Provider";
-  document.getElementById("apf-alias").value = p.alias;
-  document.getElementById("apf-model").value = p.model;
-  document.getElementById("apf-key").value = p.key;
-  document.getElementById("apf-url").value = p.url || "";
-  document.getElementById("apf-model-name").value = p.modelName || "";
-  document.getElementById("apf-default-toggle").className = p.isDefault ? "apf-toggle on" : "apf-toggle";
+  state.editingConnectionIdx = idx;
+  const c = state.aiConnections[idx];
+  document.getElementById("apf-title").textContent = "Edit Connection";
+  document.getElementById("apf-alias").value = c.alias || "";
+  document.getElementById("apf-provider").value = c.provider || "";
+  applyProviderSelection();
+  document.getElementById("apf-base-url").value = c.baseUrl || "";
+  document.getElementById("apf-key").value = c.apiKey || "";
+  // Seed the model dropdown with the current value so edit doesn't need
+  // a re-fetch; user can still hit Fetch to refresh.
+  const msel = document.getElementById("apf-model-select");
+  msel.innerHTML = c.model
+    ? `<option value="${esc(c.model)}" selected>${esc(c.model)}</option>`
+    : '<option value="">— Fetch models to populate —</option>';
+  document.getElementById("apf-model-manual").value = "";
+  document.getElementById("apf-model-manual").style.display = "none";
+  document.getElementById("apf-default-toggle").className = c.isDefault ? "apf-toggle on" : "apf-toggle";
   document.getElementById("apf-test-result").className = "apf-test-result";
   document.getElementById("btn-apf-delete").className = "apf-delete-btn show";
   document.getElementById("btn-apf-duplicate").className = "apf-duplicate-btn show";
@@ -369,7 +439,7 @@ export function initSettings() {
         const uid = state.auth.currentUser.uid;
         const snap = await getDoc(doc(state.db, "users", uid, "settings", "ai"));
         const encrypted = snap.data().encrypted;
-        state.aiProviders = await decryptData(newKey, encrypted);
+        state.aiConnections = await decryptData(newKey, encrypted);
         setVaultPp(newKey);
         status.textContent = "✓ Unlocked";
         status.className = "aip-mk-status success";
@@ -380,7 +450,7 @@ export function initSettings() {
         status.textContent = "✗ Wrong master key";
         status.className = "aip-mk-status error";
         resetBtn.style.display = "block";
-        state.aiProviders = [];
+        state.aiConnections = [];
         renderProviderList();
       }
       return;
@@ -392,7 +462,7 @@ export function initSettings() {
         const uid = state.auth.currentUser.uid;
         const snap = await getDoc(doc(state.db, "users", uid, "settings", "ai"));
         if (snap.exists() && snap.data().encrypted) {
-          state.aiProviders = await decryptData(oldKey, snap.data().encrypted);
+          state.aiConnections = await decryptData(oldKey, snap.data().encrypted);
         }
       } catch {}
       setVaultPp(newKey);
@@ -415,7 +485,7 @@ export function initSettings() {
       const uid = state.auth.currentUser.uid;
       await setDoc(doc(state.db, "users", uid, "settings", "ai"), { encrypted: null });
       state.hasOnlineProviders = false;
-      state.aiProviders = [];
+      state.aiConnections = [];
       clearVaultPp();
       renderProviderList();
       renderMasterKeyState();
@@ -445,15 +515,24 @@ export function initSettings() {
     el.className = "aip-strength " + level.cls;
   });
 
-  // Add provider
+  // Add connection
   document.getElementById("btn-aip-add").addEventListener("click", () => {
-    state.editingProviderIdx = -1;
-    document.getElementById("apf-title").textContent = "Add Provider";
+    state.editingConnectionIdx = -1;
+    // Clear the legacy-reset banner on first add — user has acknowledged.
+    state.connectionsWereReset = false;
+    document.getElementById("apf-title").textContent = "Add Connection";
     document.getElementById("apf-alias").value = "";
-    document.getElementById("apf-model").value = "gpt-5.3-codex";
+    // Default to the first catalog entry (alphabetical / catalog-defined
+    // order). Fallback empty if catalog hasn't loaded yet.
+    const firstProvider = PROVIDER_CATALOG_CACHE[0]?.id || "";
+    document.getElementById("apf-provider").value = firstProvider;
+    applyProviderSelection();
+    document.getElementById("apf-base-url").value = "";
     document.getElementById("apf-key").value = "";
-    document.getElementById("apf-url").value = "";
-    document.getElementById("apf-model-name").value = "";
+    document.getElementById("apf-model-select").innerHTML = '<option value="">— Fetch models to populate —</option>';
+    document.getElementById("apf-model-manual").value = "";
+    document.getElementById("apf-model-manual").style.display = "none";
+    document.getElementById("apf-fetch-status").textContent = "";
     document.getElementById("apf-default-toggle").className = "apf-toggle";
     document.getElementById("apf-test-result").className = "apf-test-result";
     document.getElementById("btn-apf-delete").className = "apf-delete-btn";
@@ -465,27 +544,64 @@ export function initSettings() {
   document.getElementById("apf-default-toggle").addEventListener("click", function () {
     this.classList.toggle("on");
   });
+  document.getElementById("apf-provider").addEventListener("change", applyProviderSelection);
 
-  // Save provider
+  // Manual model entry toggle — when the provider doesn't expose /models
+  // or the user wants a model not in the fetched list, flip to a plain
+  // text input. Click again to flip back.
+  document.getElementById("btn-apf-model-manual-toggle").addEventListener("click", (e) => {
+    e.preventDefault();
+    const manual = document.getElementById("apf-model-manual");
+    const select = document.getElementById("apf-model-select");
+    const link = document.getElementById("btn-apf-model-manual-toggle");
+    const isManual = manual.style.display !== "none";
+    if (isManual) {
+      manual.style.display = "none";
+      select.style.display = "";
+      link.textContent = "Enter model manually →";
+    } else {
+      manual.value = select.value || manual.value;
+      manual.style.display = "";
+      select.style.display = "none";
+      link.textContent = "← Pick from fetched list";
+    }
+  });
+
+  // Returns the model id chosen via dropdown OR manual input, whichever
+  // is currently visible. Empty string if neither.
+  function currentFormModelId() {
+    const manual = document.getElementById("apf-model-manual");
+    if (manual.style.display !== "none") return manual.value.trim();
+    return document.getElementById("apf-model-select").value.trim();
+  }
+
+  // Save connection
   document.getElementById("btn-apf-save").addEventListener("click", async () => {
     const alias = document.getElementById("apf-alias").value.trim();
-    const model = document.getElementById("apf-model").value;
-    const key = document.getElementById("apf-key").value.trim();
-    const url = document.getElementById("apf-url").value.trim();
-    const modelName = document.getElementById("apf-model-name").value.trim();
+    const providerId = document.getElementById("apf-provider").value;
+    const baseUrl = document.getElementById("apf-base-url").value.trim();
+    const apiKey = document.getElementById("apf-key").value.trim();
+    const model = currentFormModelId();
     const isDefault = document.getElementById("apf-default-toggle").classList.contains("on");
-    if (!alias || !key) { alert("Alias and API Key are required"); return; }
+    const catalogEntry = PROVIDER_CATALOG_CACHE.find(p => p.id === providerId);
+    if (!alias || !apiKey) { alert("Alias and API Key are required"); return; }
+    if (!providerId || !catalogEntry) { alert("Pick a Provider"); return; }
+    if (catalogEntry.requiresBaseUrl && !baseUrl) { alert("Base URL is required for this provider"); return; }
+    if (!model) { alert("Pick a Model (Fetch from the provider or enter manually)"); return; }
 
-    if (isDefault) state.aiProviders.forEach(p => p.isDefault = false);
+    if (isDefault) state.aiConnections.forEach(p => p.isDefault = false);
 
-    if (state.editingProviderIdx >= 0) {
-      const p = state.aiProviders[state.editingProviderIdx];
-      p.alias = alias; p.model = model; p.key = key; p.url = url;
-      p.modelName = modelName; p.isDefault = isDefault;
+    const next = {
+      alias, provider: providerId, model,
+      apiKey,
+      baseUrl: baseUrl || undefined,
+      isDefault,
+    };
+    if (state.editingConnectionIdx >= 0) {
+      const p = state.aiConnections[state.editingConnectionIdx];
+      Object.assign(p, next);
     } else {
-      state.aiProviders.push({
-        id: crypto.randomUUID(), alias, model, key, url, modelName, isDefault,
-      });
+      state.aiConnections.push({ id: crypto.randomUUID(), ...next });
     }
 
     await saveProviders();
@@ -493,40 +609,42 @@ export function initSettings() {
     showView("ai-providers");
   });
 
-  // Delete provider
+  // Delete connection
   document.getElementById("btn-apf-delete").addEventListener("click", async () => {
-    if (!confirm("Delete this provider?")) return;
-    state.aiProviders.splice(state.editingProviderIdx, 1);
+    if (!confirm("Delete this connection?")) return;
+    state.aiConnections.splice(state.editingConnectionIdx, 1);
     await saveProviders();
     renderProviderList();
     showView("ai-providers");
   });
 
-  // Duplicate provider — clones the currently edited entry with a fresh
-  // id, " (copy)" suffix on the alias, and isDefault forced off. Stays
-  // on the list so the user can tweak either copy.
+  // Duplicate connection — clones the currently edited entry with a
+  // fresh id, " (copy)" suffix on the alias, and isDefault forced off.
   document.getElementById("btn-apf-duplicate").addEventListener("click", async () => {
-    if (state.editingProviderIdx < 0) return;
-    const src = state.aiProviders[state.editingProviderIdx];
+    if (state.editingConnectionIdx < 0) return;
+    const src = state.aiConnections[state.editingConnectionIdx];
     const copy = {
       ...src,
       id: crypto.randomUUID(),
       alias: `${src.alias} (copy)`,
       isDefault: false,
     };
-    state.aiProviders.push(copy);
+    state.aiConnections.push(copy);
     await saveProviders();
     renderProviderList();
     showView("ai-providers");
   });
 
-  // Test connection
+  // Test connection — send a minimal chat to /chat using the in-progress
+  // form values (not yet saved). Lets the user verify key + url + model
+  // before committing the Connection.
   document.getElementById("btn-apf-test").addEventListener("click", async () => {
-    const model = document.getElementById("apf-model").value;
-    const key = document.getElementById("apf-key").value.trim();
-    const url = document.getElementById("apf-url").value.trim();
-    const modelName = document.getElementById("apf-model-name").value.trim();
-    if (!key) { alert("Enter an API key first"); return; }
+    const providerId = document.getElementById("apf-provider").value;
+    const baseUrl = document.getElementById("apf-base-url").value.trim();
+    const apiKey = document.getElementById("apf-key").value.trim();
+    const model = currentFormModelId();
+    if (!apiKey) { alert("Enter an API key first"); return; }
+    if (!model) { alert("Pick a Model first"); return; }
 
     const btn = document.getElementById("btn-apf-test");
     btn.textContent = "Testing...";
@@ -542,12 +660,9 @@ export function initSettings() {
           message: "Say hi in one word",
           files: [],
           history: [],
+          provider: providerId,
           model,
-          byok: {
-            key,
-            url: url || undefined,
-            modelName: modelName || undefined,
-          },
+          byok: { apiKey, baseUrl: baseUrl || undefined },
         }),
       });
       const elapsed = Date.now() - start;
@@ -558,7 +673,7 @@ export function initSettings() {
         document.getElementById("apf-test-title").style.color = "#6c6";
         document.getElementById("apf-test-detail").textContent = `Response: ${elapsed}ms`;
       } else {
-        throw new Error(data.error || data.detail || "Unknown error");
+        throw new Error(data.error || `HTTP ${res.status}`);
       }
     } catch (e) {
       result.className = "apf-test-result fail show";
@@ -569,15 +684,18 @@ export function initSettings() {
     btn.textContent = "⚡ Test Connection";
   });
 
-  // Fetch model list — calls mono-api /models with the BYOK url+key,
-  // populates the Custom Model Name datalist for autocomplete.
+  // Fetch model list — calls /models with { provider, apiKey, baseUrl? }
+  // and populates the Model dropdown. Manual-entry fallback is always
+  // available via the "Enter model manually" link below the field.
   document.getElementById("btn-apf-fetch-models").addEventListener("click", async () => {
-    const model = document.getElementById("apf-model").value;
-    const key = document.getElementById("apf-key").value.trim();
-    const url = document.getElementById("apf-url").value.trim();
+    const providerId = document.getElementById("apf-provider").value;
+    const apiKey = document.getElementById("apf-key").value.trim();
+    const baseUrl = document.getElementById("apf-base-url").value.trim();
     const status = document.getElementById("apf-fetch-status");
     const btn = document.getElementById("btn-apf-fetch-models");
-    if (!key) { status.textContent = "Enter an API key first"; status.className = "apf-fetch-status warn"; return; }
+    const select = document.getElementById("apf-model-select");
+    if (!apiKey) { status.textContent = "Enter an API key first"; status.className = "apf-fetch-status warn"; return; }
+    if (!providerId) { status.textContent = "Pick a Provider first"; status.className = "apf-fetch-status warn"; return; }
 
     btn.disabled = true;
     btn.textContent = "Fetching…";
@@ -588,36 +706,39 @@ export function initSettings() {
       const res = await apiFetch("/models", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url: url || undefined, key, model }),
+        body: JSON.stringify({ provider: providerId, apiKey, baseUrl: baseUrl || undefined }),
       });
       const data = await res.json();
-      if (!res.ok) throw new Error(data.error || data.detail || `HTTP ${res.status}`);
-      const list = document.getElementById("apf-model-name-list");
-      list.innerHTML = "";
-      const models = data.models || [];
-      // Sort: reasoning-capable first, then vision, then alpha.
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      const models = (data.models || []).slice();
+      // Sort: reasoning first, then vision, then alpha.
       models.sort((a, b) => {
         if (a.reasoning !== b.reasoning) return a.reasoning ? -1 : 1;
         if (a.vision !== b.vision) return a.vision ? -1 : 1;
         return a.id.localeCompare(b.id);
       });
-      for (const m of models) {
-        const opt = document.createElement("option");
-        opt.value = m.id;
+      const prevValue = select.value;
+      select.innerHTML = models.map(m => {
         const tags = [];
         if (m.reasoning) tags.push("reasoning");
         if (m.vision) tags.push("vision");
         if (m.context) tags.push(`${Math.round(m.context / 1024)}K ctx`);
-        if (tags.length) opt.label = `${m.id} — ${tags.join(", ")}`;
-        list.appendChild(opt);
-      }
-      status.textContent = `✓ ${models.length} models — type or click the field to browse`;
+        const label = tags.length ? `${m.id} — ${tags.join(", ")}` : m.id;
+        return `<option value="${esc(m.id)}">${esc(label)}</option>`;
+      }).join("");
+      // Preserve prior selection if it survived the new list.
+      if (prevValue && models.some(m => m.id === prevValue)) select.value = prevValue;
+      status.textContent = `✓ ${models.length} models`;
       status.className = "apf-fetch-status success";
     } catch (e) {
-      status.textContent = `✗ ${e.message}`;
+      status.textContent = `✗ ${e.message} — use "Enter model manually" if the provider has no /models`;
       status.className = "apf-fetch-status error";
     }
     btn.disabled = false;
     btn.textContent = "🔍 Fetch";
   });
+
+  // Kick off one-time catalog load so the Provider dropdown is populated
+  // by the time the user clicks Add Connection.
+  loadProviderCatalog();
 }

--- a/dev/js/settings.js
+++ b/dev/js/settings.js
@@ -292,18 +292,23 @@ function renderProviderDropdown() {
 }
 
 // Show / hide the Base URL field based on provider.requiresBaseUrl.
+// The placeholder reflects the catalog baseUrl (or a sensible template
+// for providers requiring a custom relay) so users see the expected
+// shape without typing it.
 function applyProviderSelection() {
   const providerId = document.getElementById("apf-provider").value;
   const p = PROVIDER_CATALOG_CACHE.find(x => x.id === providerId);
   const field = document.getElementById("apf-base-url-field");
   const hint = document.getElementById("apf-base-url-hint");
+  const input = document.getElementById("apf-base-url");
   if (!p) return;
+  field.style.display = "";
   if (p.requiresBaseUrl) {
-    field.style.display = "";
     hint.textContent = "Required — your relay's base URL";
+    input.placeholder = "https://your-relay.example.com";
   } else {
-    field.style.display = "";
     hint.textContent = `Optional — default ${p.baseUrl || ""}`;
+    input.placeholder = p.baseUrl || "";
   }
   // Clear model list — it's provider-specific.
   document.getElementById("apf-model-select").innerHTML = '<option value="">— Fetch models to populate —</option>';

--- a/dev/js/settings.js
+++ b/dev/js/settings.js
@@ -179,7 +179,7 @@ export function updateModelSelector() {
   const pillLabel = document.querySelector("#btn-provider-pill .pill-label");
   if (pillLabel) {
     pillLabel.textContent = sel.options.length === 0
-      ? "No provider"
+      ? "No connection"
       : (sel.options[sel.selectedIndex]?.textContent || "Model");
   }
 }
@@ -227,7 +227,7 @@ function renderMasterKeyState() {
     input.placeholder = "Enter your master key to unlock";
     actionBtn.textContent = "Unlock";
     actionBtn.style.display = "block";
-    subtitle.textContent = "Encrypted providers found. Enter your master key to unlock.";
+    subtitle.textContent = "Encrypted connections found. Enter your master key to unlock.";
     subtitle.style.color = "#fa3";
     status.textContent = "";
   } else {
@@ -467,7 +467,7 @@ export function initSettings() {
       } catch {}
       setVaultPp(newKey);
       await saveProviders();
-      status.textContent = "✓ Master key changed and providers re-encrypted";
+      status.textContent = "✓ Master key changed and connections re-encrypted";
       status.className = "aip-mk-status success";
       renderMasterKeyState();
       return;
@@ -480,7 +480,7 @@ export function initSettings() {
 
   // Reset
   document.getElementById("aip-mk-reset").addEventListener("click", async () => {
-    if (!confirm("This will delete all saved providers. Are you sure?")) return;
+    if (!confirm("This will delete all saved connections. Are you sure?")) return;
     try {
       const uid = state.auth.currentUser.uid;
       await setDoc(doc(state.db, "users", uid, "settings", "ai"), { encrypted: null });
@@ -489,7 +489,7 @@ export function initSettings() {
       clearVaultPp();
       renderProviderList();
       renderMasterKeyState();
-      document.getElementById("aip-mk-status").textContent = "Providers cleared";
+      document.getElementById("aip-mk-status").textContent = "Connections cleared";
       document.getElementById("aip-mk-status").className = "aip-mk-status warn";
     } catch (e) {
       alert("Failed: " + e.message);

--- a/dev/js/state.js
+++ b/dev/js/state.js
@@ -20,10 +20,17 @@ export const state = {
   gameRunning: false,
   sessionTokens: { prompt: 0, completion: 0, total: 0 },
 
-  // AI providers
-  aiProviders: [],       // { id, alias, model, key, url, isDefault }
+  // AI Assistant — user's Connections: { id, alias, provider, model,
+  // apiKey, baseUrl?, isDefault }. `provider` keys into the server's
+  // PROVIDER_CATALOG (fetched via /config); `model` is an id chosen
+  // from a live /models query (or manually typed as a fallback).
+  aiConnections: [],
   hasOnlineProviders: false,
-  editingProviderIdx: -1,
+  editingConnectionIdx: -1,
+  // One-shot banner: set to true when loadConnections() detects a
+  // legacy vault shape (pre-catalog) and wipes it. Rendered in the
+  // AI settings view so the user knows why their entries disappeared.
+  connectionsWereReset: false,
   vaultPp: null,         // in-memory master key when local-save is disabled
 
   // Local sync

--- a/dev/test-worker.js
+++ b/dev/test-worker.js
@@ -22,10 +22,22 @@ function buildPalette(bits) {
 }
 
 onmessage = async (e) => {
-  const { files, frames = 30, colors = 4 } = e.data;
+  const { files, frames = 30, colors = 4, inputScript = null } = e.data;
   const errors = [];
   const output = [];
   let palette = buildPalette(colors);
+
+  // Mutable input state driven by `inputScript` events. Mirrors the
+  // browser engine's edge-detected fields (touchStart / touchEnd) and
+  // the release-snapshot semantics (endedTouches while touchEnd is true),
+  // so scripted taps exercise the same code paths as real user input.
+  // inputScript = [{ frame: N, touchStart?: true, touchEnd?: true, touches?: [{x,y}] }, ...]
+  const inputState = {
+    touches: [],
+    endedTouches: [],
+    touchStarted: false,
+    touchEnded: false,
+  };
 
   const surfaces = {};
   let surfIdCounter = 1;
@@ -51,13 +63,22 @@ onmessage = async (e) => {
       if (f.name === "main.lua" || !f.name.endsWith(".lua")) continue;
       modules[f.name] = f.content;
     }
+    const posLookup = (i) => {
+      const idx = (i || 1) - 1;
+      return inputState.touches[idx]
+          || (inputState.touchEnded ? inputState.endedTouches[idx] : null);
+    };
     await self.MonoBindings.bind(lua, {
       input: {
         btn: () => false, btnp: () => false, btnr: () => false,
-        touch: () => false, touchStart: () => false, touchEnd: () => false,
-        touchCount: () => 0,
-        touchPosX: () => false, touchPosY: () => false,
-        touchPosfX: () => false, touchPosfY: () => false,
+        touch:      () => inputState.touches.length > 0 || inputState.touchStarted,
+        touchStart: () => inputState.touchStarted,
+        touchEnd:   () => inputState.touchEnded,
+        touchCount: () => inputState.touches.length || (inputState.touchEnded ? inputState.endedTouches.length : 0),
+        touchPosX:  (i) => { const t = posLookup(i); return t ? t.x : false; },
+        touchPosY:  (i) => { const t = posLookup(i); return t ? t.y : false; },
+        touchPosfX: (i) => { const t = posLookup(i); return t ? t.x : false; },
+        touchPosfY: (i) => { const t = posLookup(i); return t ? t.y : false; },
         swipe: () => false,
         axisX: () => 0, axisY: () => 0,
       },
@@ -219,8 +240,35 @@ onmessage = async (e) => {
 
     if (sceneRef.pending) { await activateScene(sceneRef.pending); sceneRef.pending = null; }
 
+    // Index inputScript by frame for O(1) lookup.
+    const scriptByFrame = {};
+    if (Array.isArray(inputScript)) {
+      for (const ev of inputScript) {
+        if (typeof ev?.frame === "number") scriptByFrame[ev.frame] = ev;
+      }
+    }
+
     for (let i = 0; i < frames; i++) {
       if (sceneRef.pending) { await activateScene(sceneRef.pending); sceneRef.pending = null; }
+
+      // Clear last-frame edges before applying this frame's event. Mirrors
+      // the browser engine's `if (touchEnded) endedTouches = []` reset.
+      if (inputState.touchEnded) inputState.endedTouches = [];
+      inputState.touchStarted = false;
+      inputState.touchEnded = false;
+
+      const ev = scriptByFrame[i];
+      if (ev) {
+        if (Array.isArray(ev.touches)) inputState.touches = ev.touches.map(t => ({ ...t }));
+        if (ev.touchStart) inputState.touchStarted = true;
+        if (ev.touchEnd) {
+          inputState.touchEnded = true;
+          // Snapshot current touches into endedTouches, then clear (same
+          // timing as the browser onTouchEnd handler).
+          inputState.endedTouches = inputState.touches.map(t => ({ ...t }));
+          if (ev.touches === undefined) inputState.touches = [];
+        }
+      }
 
       if (sceneObj?.update) { sceneObj.update(); }
       else {

--- a/editor/templates/mono/mono-test.js
+++ b/editor/templates/mono/mono-test.js
@@ -563,8 +563,7 @@ function applyTouch(frame) {
 }
 
 function touchUpdate() {
-  touchStarted = touchStartedFlag;
-  touchEnded = touchEndedFlag;
+  // Clear edge flags at frame end — uf() has had one shot to observe them.
   touchStartedFlag = false;
   touchEndedFlag = false;
 }
@@ -835,9 +834,12 @@ async function main() {
       btn:  (k) => !!keys[k],
       btnp: (k) => !!(keys[k] && !keysPrev[k]),
       btnr: (k) => !!(!keys[k] && keysPrev[k]),
-      touch:      () => touches.length > 0 || touchStartedFlag,
-      touchStart: () => touchStarted || touchStartedFlag,
-      touchEnd:   () => touchEnded || touchEndedFlag,
+      touch:      () => touches.length > 0,
+      // touch_start/touch_end are edge-triggered: visible for exactly one
+      // frame starting on the frame the event was dispatched. Match runtime
+      // engine.js semantics (see engine.js MonoBindings input block).
+      touchStart: () => touchStartedFlag,
+      touchEnd:   () => touchEndedFlag,
       touchCount: () => touches.length,
       touchPosX:  (i) => { const t = touches[(i || 1) - 1]; return t ? t.x  : false; },
       touchPosY:  (i) => { const t = touches[(i || 1) - 1]; return t ? t.y  : false; },

--- a/editor/templates/mono/mono-test.js
+++ b/editor/templates/mono/mono-test.js
@@ -994,7 +994,7 @@ end
           // Single key or comma-separated: "up" or "up,a"
           for (const k of action.split(",")) {
             const key = k.trim();
-            if (key && validKeys[key]) keys[key] = true;
+            if (key && MonoBindings.VALID_KEYS[key]) keys[key] = true;
           }
         }
       } catch (e) {

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -563,13 +563,11 @@ var Mono = (() => {
     // game has opted out via use_pause(false).
     if (pauseEnabled && keys["select"] && !keysPrev["select"]) paused = !paused;
 
-    // Touch edge detection (persists one frame, like btnp). endedTouches
-    // is the release-position snapshot accessed through touch_pos(i) during
-    // that single frame; clear it once the frame ticks past so stale data
-    // can't leak into later turns.
-    if (touchEnded && !touchEndedFlag) endedTouches = [];
-    touchStarted = touchStartedFlag;
-    touchEnded = touchEndedFlag;
+    // Touch edge flags are cleared here at frame end, after uf() has had
+    // one shot at observing them via touchStart() / touchEnd(). endedTouches
+    // holds the release snapshot consumed by touch_pos(i) during touch_end();
+    // clear it at the same time as the flag so stale data can't leak forward.
+    if (touchEndedFlag) endedTouches = [];
     touchStartedFlag = false;
     touchEndedFlag = false;
     swipeDir = swipeDirFlag;
@@ -1020,17 +1018,21 @@ var Mono = (() => {
         btn:        (k) => !!keys[k],
         btnp:       (k) => !!(keys[k] && !keysPrev[k]),
         btnr:       (k) => !!(!keys[k] && keysPrev[k]),
-        touch:      () => touches.length > 0 || touchStartedFlag,
-        touchStart: () => touchStarted || touchStartedFlag,
-        touchEnd:   () => touchEnded || touchEndedFlag,
-        touchCount: () => touches.length || (touchEnded || touchEndedFlag ? endedTouches.length : 0),
+        touch:      () => touches.length > 0,
+        // touch_start/touch_end are edge-triggered: true for exactly one update
+        // frame, beginning on the frame the event was dispatched. The previous
+        // `state || flag` form caused a 2-frame visibility bleed that could leak
+        // an event into a scene activated via go() on the same frame.
+        touchStart: () => touchStartedFlag,
+        touchEnd:   () => touchEndedFlag,
+        touchCount: () => touches.length || (touchEndedFlag ? endedTouches.length : 0),
         // While touch_end() is true (one frame), fall back to the release
         // snapshot so `if touch_end() then local x, y = touch_pos(1) end`
         // returns the lift coordinates instead of false.
-        touchPosX:  (i) => { const t = touches[(i || 1) - 1] || ((touchEnded || touchEndedFlag) ? endedTouches[(i || 1) - 1] : null); return t ? t.x  : false; },
-        touchPosY:  (i) => { const t = touches[(i || 1) - 1] || ((touchEnded || touchEndedFlag) ? endedTouches[(i || 1) - 1] : null); return t ? t.y  : false; },
-        touchPosfX: (i) => { const t = touches[(i || 1) - 1] || ((touchEnded || touchEndedFlag) ? endedTouches[(i || 1) - 1] : null); return t ? t.fx : false; },
-        touchPosfY: (i) => { const t = touches[(i || 1) - 1] || ((touchEnded || touchEndedFlag) ? endedTouches[(i || 1) - 1] : null); return t ? t.fy : false; },
+        touchPosX:  (i) => { const t = touches[(i || 1) - 1] || (touchEndedFlag ? endedTouches[(i || 1) - 1] : null); return t ? t.x  : false; },
+        touchPosY:  (i) => { const t = touches[(i || 1) - 1] || (touchEndedFlag ? endedTouches[(i || 1) - 1] : null); return t ? t.y  : false; },
+        touchPosfX: (i) => { const t = touches[(i || 1) - 1] || (touchEndedFlag ? endedTouches[(i || 1) - 1] : null); return t ? t.fx : false; },
+        touchPosfY: (i) => { const t = touches[(i || 1) - 1] || (touchEndedFlag ? endedTouches[(i || 1) - 1] : null); return t ? t.fy : false; },
         swipe: () => swipeDir || false,
         axisX: () => axisX,
         axisY: () => axisY,

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -432,6 +432,13 @@ var Mono = (() => {
 
   // --- Touch / Mouse ---
   let touches = [];           // [{ id, x, y, fx, fy }]
+  // Snapshot of touches removed by the most recent `touchend` DOM event.
+  // touch_pos(i) falls back to this while touch_end() is true so that
+  //   if touch_end() then local x, y = touch_pos(1) end
+  // reads the release position instead of false — otherwise splice()
+  // happens before touchEndedFlag flips, leaving touches[] empty on the
+  // single frame touch_end() fires.
+  let endedTouches = [];
   let touchStartedFlag = false;
   let touchEndedFlag = false;
   let touchStarted = false;
@@ -556,7 +563,11 @@ var Mono = (() => {
     // game has opted out via use_pause(false).
     if (pauseEnabled && keys["select"] && !keysPrev["select"]) paused = !paused;
 
-    // Touch edge detection (persists one frame, like btnp)
+    // Touch edge detection (persists one frame, like btnp). endedTouches
+    // is the release-position snapshot accessed through touch_pos(i) during
+    // that single frame; clear it once the frame ticks past so stale data
+    // can't leak into later turns.
+    if (touchEnded && !touchEndedFlag) endedTouches = [];
     touchStarted = touchStartedFlag;
     touchEnded = touchEndedFlag;
     touchStartedFlag = false;
@@ -732,9 +743,13 @@ var Mono = (() => {
 
       const onTouchEnd = (e) => {
         e.preventDefault();
+        // Snapshot release positions BEFORE splice so touch_pos(i) on
+        // the touch_end() frame still returns the last coord.
+        endedTouches = [];
         for (const t of e.changedTouches) {
           const idx = touches.findIndex(tt => tt.id === t.identifier);
           if (idx >= 0) {
+            endedTouches.push({ ...touches[idx] });
             detectSwipe(touches[idx].fx, touches[idx].fy);
             touches.splice(idx, 1);
           }
@@ -766,8 +781,10 @@ var Mono = (() => {
       on(document, "mouseup", () => {
         if (!mouseDown) return;
         mouseDown = false;
+        endedTouches = [];
         const idx = touches.findIndex(t => t.id === -1);
         if (idx >= 0) {
+          endedTouches.push({ ...touches[idx] });
           detectSwipe(touches[idx].fx, touches[idx].fy);
           touches.splice(idx, 1);
         }
@@ -1006,11 +1023,14 @@ var Mono = (() => {
         touch:      () => touches.length > 0 || touchStartedFlag,
         touchStart: () => touchStarted || touchStartedFlag,
         touchEnd:   () => touchEnded || touchEndedFlag,
-        touchCount: () => touches.length,
-        touchPosX:  (i) => { const t = touches[(i || 1) - 1]; return t ? t.x  : false; },
-        touchPosY:  (i) => { const t = touches[(i || 1) - 1]; return t ? t.y  : false; },
-        touchPosfX: (i) => { const t = touches[(i || 1) - 1]; return t ? t.fx : false; },
-        touchPosfY: (i) => { const t = touches[(i || 1) - 1]; return t ? t.fy : false; },
+        touchCount: () => touches.length || (touchEnded || touchEndedFlag ? endedTouches.length : 0),
+        // While touch_end() is true (one frame), fall back to the release
+        // snapshot so `if touch_end() then local x, y = touch_pos(1) end`
+        // returns the lift coordinates instead of false.
+        touchPosX:  (i) => { const t = touches[(i || 1) - 1] || ((touchEnded || touchEndedFlag) ? endedTouches[(i || 1) - 1] : null); return t ? t.x  : false; },
+        touchPosY:  (i) => { const t = touches[(i || 1) - 1] || ((touchEnded || touchEndedFlag) ? endedTouches[(i || 1) - 1] : null); return t ? t.y  : false; },
+        touchPosfX: (i) => { const t = touches[(i || 1) - 1] || ((touchEnded || touchEndedFlag) ? endedTouches[(i || 1) - 1] : null); return t ? t.fx : false; },
+        touchPosfY: (i) => { const t = touches[(i || 1) - 1] || ((touchEnded || touchEndedFlag) ? endedTouches[(i || 1) - 1] : null); return t ? t.fy : false; },
         swipe: () => swipeDir || false,
         axisX: () => axisX,
         axisY: () => axisY,
@@ -1156,7 +1176,7 @@ var Mono = (() => {
     bootTime = performance.now();
     images = []; imageIdCounter = 0; pendingLoads = [];
     camX = 0; camY = 0; shakeAmount = 0; shakeX = 0; shakeY = 0; sfxStop(); surfaces = [];
-    touches = []; touchStarted = false; touchEnded = false; touchStartedFlag = false; touchEndedFlag = false;
+    touches = []; endedTouches = []; touchStarted = false; touchEnded = false; touchStartedFlag = false; touchEndedFlag = false;
     swipeDir = false; swipeDirFlag = false; swipeAnchor = null;
     sceneRef.current = null; sceneRef.pending = null; loadedSceneFiles = {};
   };
@@ -1180,7 +1200,7 @@ var Mono = (() => {
     // state equivalently idle.
     for (const k in keys) { keys[k] = false; keysPrev[k] = false; }
     axisX = 0; axisY = 0;
-    touches = []; touchStarted = false; touchEnded = false;
+    touches = []; endedTouches = []; touchStarted = false; touchEnded = false;
     touchStartedFlag = false; touchEndedFlag = false;
     swipeDir = false; swipeDirFlag = false; swipeAnchor = null;
     releaseWakeLock();


### PR DESCRIPTION
## Summary

Reframes the AI feature around a clean **AI Assistant → Provider → Model → Connection** hierarchy and lands the agentic tool-use loop as the primary path for OpenAI-protocol Connections.

- BYOK Connection editor: provider-first cascade (vendor dropdown → live `/models` query → model dropdown, with manual-input fallback for relays). Vault-encrypted per-user storage in Firestore. Old "AI Provider" preset shape detected on load and wiped with a one-shot reset banner.
- Live agent UX: streaming reasoning + tool rows + token output interleaved in the working card; on final, the whole card collapses into a completed card with a "▸ Show trace (N iter · M tools · K tok)" footer. Reasoning forwards as deltas (matches token streaming cadence) instead of one bulk emit at turn end.
- Auto smoke-test harness: every `.lua` write triggers a headless 40-frame run with a scripted touch-down → touch-end scenario through `defaultSmokeScenario()`. Runtime crashes surface inline as `SMOKE TEST FAILED` instead of waiting for next Play.
- Engine fix: `touch_end()` now snapshots release positions into `endedTouches[]` so `if touch_end() then local x, y = touch_pos(1) end` returns the lift coords on that single frame instead of `false`. Edge-flag getters cleaned up (one-frame visibility, matches `btnp`/`btnr`).
- `validKeys` shadowing fixed to source from `MonoBindings.VALID_KEYS` in the headless test runner.

## Test plan

- [ ] Settings → AI Assistant: legacy reset banner appears on first load if the vault held the old provider/model preset shape.
- [ ] Add Connection: Provider dropdown populates from `/config`; Base URL placeholder updates per provider; Fetch Models populates dropdown; Enter Manually toggle works.
- [ ] Run a tool-use chat against an OpenAI-protocol provider (Moonshot, OpenAI, ApiMart, Custom relay): live trace shows reasoning/tool rows/tokens; final card folds with collapsible trace; tools link to actual R2 file changes.
- [ ] Anthropic / Google connections fall back to `/chat` (one-shot), no agent path; reasoning round-trips correctly across Anthropic turns.
- [ ] Path-traversal attempt via crafted tool input (e.g., `{ "path": "../other" }`) is rejected at server with a clear error.
- [ ] Edit a `.lua` file via agent that introduces a runtime error → smoke test card appears red with the lua error.
- [ ] Touch-end scene transition (e.g., title → game) doesn't double-fire on the next frame after `2323d7c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)