### PR TITLE
feat(lint): unknown-api rule — only allow API.md + Lua stdlib + locals

### DIFF
--- a/.claude/scripts/lib/engine-apis.js
+++ b/.claude/scripts/lib/engine-apis.js
@@ -3,8 +3,7 @@
 // Centralizes knowledge of the Mono engine's public API surface and the
 // mapping between internal `_`-prefixed glue helpers and their user-facing
 // wrapper names. Consumed by:
-//   - .claude/scripts/mono-lint.js          (defensive-api-check rule)
-//   - .claude/scripts/mono-docs-sync.js     (DEV.md drift detection)
+//   - .claude/scripts/mono-lint.js          (defensive-api-check, unknown-api rules)
 //   - editor/templates/mono/mono-test.js    (--coverage report)
 //
 // Keep this file minimal and zero-dependency (no third-party imports) so
@@ -41,6 +40,7 @@ const INTERNAL_TO_PUBLIC = Object.freeze({
 // Scripts can override with an explicit path argument.
 const DEFAULT_REPO_ROOT = path.resolve(__dirname, "../../..");
 const DEFAULT_ENGINE_JS = path.join(DEFAULT_REPO_ROOT, "runtime/engine.js");
+const DEFAULT_API_MD    = path.join(DEFAULT_REPO_ROOT, "docs/API.md");
 
 /**
  * Parse `runtime/engine.js` and return the set of public API names
@@ -96,9 +96,36 @@ function buildCoverageRename() {
   return out;
 }
 
+/**
+ * Parse `docs/API.md` (the auto-generated API reference) and return the set
+ * of API names rendered in the doc — both the documented entries
+ * (`### name(args): type`) and the bare-name entries in the Misc section
+ * (`### name`).
+ *
+ * Use this when you want the canonical "what game code is allowed to call"
+ * surface — it includes APIs registered via `lua.global.set` in either
+ * runtime/engine.js OR runtime/engine-bindings.js, plus any API.md header
+ * additions.
+ *
+ * @param {string} [apiMdPath] — absolute path to API.md (defaults to docs/API.md)
+ * @returns {Set<string>}
+ */
+function loadAPIsFromMd(apiMdPath) {
+  const file = apiMdPath || DEFAULT_API_MD;
+  const names = new Set();
+  if (!fs.existsSync(file)) return names;
+  const src = fs.readFileSync(file, "utf8");
+  const re = /^### ([a-zA-Z_][a-zA-Z0-9_]*)\b/gm;
+  let m;
+  while ((m = re.exec(src)) !== null) names.add(m[1]);
+  return names;
+}
+
 module.exports = {
   INTERNAL_TO_PUBLIC,
   loadPublicAPIs,
+  loadAPIsFromMd,
   buildCoverageRename,
   DEFAULT_ENGINE_JS,
+  DEFAULT_API_MD,
 };

--- a/.claude/scripts/lib/lua-analysis.js
+++ b/.claude/scripts/lib/lua-analysis.js
@@ -1,0 +1,310 @@
+// lua-analysis.js — Lua AST analysis for the mono-lint unknown-api rule.
+//
+// Parses a Lua file with `luaparse`, classifies every call site as either
+// known (engine API / Lua stdlib / locally defined / required-module export)
+// or unknown. require()'d modules are recursively analyzed so their exports
+// participate in the check.
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const luaparse = require("luaparse");
+
+const STDLIB = require("./lua-stdlib.json");
+
+// Stdlib top-level globals (assert, print, pairs, ...) are checked against
+// STDLIB._G. Stdlib modules (math, string, ...) get their own member lookup.
+const STDLIB_GLOBALS = new Set(STDLIB._G);
+const STDLIB_MODULES = new Set(Object.keys(STDLIB).filter(k => k !== "_G"));
+
+// Lifecycle hooks the engine calls into. Game code may legitimately call
+// them again (e.g. `_init()` to restart). Whitelisted even when the file
+// being linted doesn't declare them — they're either declared elsewhere or
+// resolve to nil at runtime.
+const LIFECYCLE_HOOKS = new Set(["_init", "_start", "_ready", "_update", "_draw"]);
+
+// Lua version to feed luaparse. Mono runs Lua 5.4 via Wasmoon; 5.3 is the
+// closest version luaparse fully supports (covers `goto`/`::label::`,
+// integer division, bitwise ops).
+const LUA_VERSION = "5.3";
+
+/** Decode a luaparse StringLiteral. luaparse leaves `value` null by default
+ * and stores the source-form (with surrounding quotes) on `raw`. We strip
+ * the outer quote pair — sufficient for our uses (require paths, table
+ * keys), no escape-sequence handling needed because Mono module paths
+ * don't use them. */
+function stringLitValue(node) {
+  if (!node || node.type !== "StringLiteral") return null;
+  if (node.value !== null && node.value !== undefined) return node.value;
+  if (typeof node.raw !== "string" || node.raw.length < 2) return null;
+  return node.raw.slice(1, -1);
+}
+
+/** Walk every node in a luaparse AST, depth-first. */
+function walk(node, cb) {
+  if (!node || typeof node !== "object") return;
+  cb(node);
+  for (const key of Object.keys(node)) {
+    if (key === "loc" || key === "range") continue;
+    const val = node[key];
+    if (!val || typeof val !== "object") continue;
+    if (Array.isArray(val)) {
+      for (const v of val) if (v && typeof v === "object" && v.type) walk(v, cb);
+    } else if (val.type) {
+      walk(val, cb);
+    }
+  }
+}
+
+/**
+ * Collect symbols defined in a parsed AST.
+ * Returns:
+ *   locals          — Set of names declared via `local`
+ *   globals         — Set of names declared via top-level assignment / `function name()`
+ *   tableModules    — Map<varName, Set<member>> for `local M = {}; function M.x() end` patterns
+ *   requireBindings — Map<varName, modulePath> for `local foo = require("path")`
+ *   returnedTable   — varName the chunk returns (e.g. `return scene`), or null
+ *   returnedTableLiteral — Set<member> if the chunk returns a literal table, else null
+ */
+function collectSymbols(ast) {
+  const locals = new Set();
+  const globals = new Set();
+  const tableModules = new Map();
+  const requireBindings = new Map();
+  let returnedTable = null;
+  let returnedTableLiteral = null;
+
+  walk(ast, (node) => {
+    switch (node.type) {
+      case "LocalStatement": {
+        for (let i = 0; i < node.variables.length; i++) {
+          const v = node.variables[i];
+          const init = node.init[i];
+          if (v.type !== "Identifier") continue;
+          locals.add(v.name);
+          if (!init) continue;
+          if (init.type === "CallExpression"
+              && init.base.type === "Identifier"
+              && init.base.name === "require"
+              && init.arguments.length === 1
+              && init.arguments[0].type === "StringLiteral") {
+            const modPath = stringLitValue(init.arguments[0]);
+            if (modPath) requireBindings.set(v.name, modPath);
+          } else if (init.type === "TableConstructorExpression") {
+            const exports = new Set();
+            for (const field of init.fields) {
+              const key = fieldKeyName(field);
+              if (key) exports.add(key);
+            }
+            tableModules.set(v.name, exports);
+          }
+        }
+        break;
+      }
+      case "FunctionDeclaration": {
+        const id = node.identifier;
+        if (!id) break;
+        if (id.type === "Identifier") {
+          if (node.isLocal) locals.add(id.name);
+          else globals.add(id.name);
+        } else if (id.type === "MemberExpression"
+                && id.base.type === "Identifier") {
+          const mod = tableModules.get(id.base.name);
+          if (mod) mod.add(id.identifier.name);
+        }
+        break;
+      }
+      case "AssignmentStatement": {
+        for (const v of node.variables) {
+          if (v.type === "Identifier") {
+            if (!locals.has(v.name)) globals.add(v.name);
+          } else if (v.type === "MemberExpression"
+                  && v.base.type === "Identifier") {
+            const mod = tableModules.get(v.base.name);
+            if (mod) mod.add(v.identifier.name);
+          }
+        }
+        break;
+      }
+    }
+  });
+
+  // Find chunk-level return (last top-level statement).
+  for (const stmt of ast.body) {
+    if (stmt.type === "ReturnStatement" && stmt.arguments.length > 0) {
+      const ret = stmt.arguments[0];
+      if (ret.type === "Identifier") returnedTable = ret.name;
+      else if (ret.type === "TableConstructorExpression") {
+        returnedTableLiteral = new Set();
+        for (const field of ret.fields) {
+          const key = fieldKeyName(field);
+          if (key) returnedTableLiteral.add(key);
+        }
+      }
+    }
+  }
+
+  return { locals, globals, tableModules, requireBindings, returnedTable, returnedTableLiteral };
+}
+
+/** Return the string key of a TableConstructor field, or null. */
+function fieldKeyName(field) {
+  if (field.type === "TableKeyString" && field.key?.type === "Identifier") {
+    return field.key.name;
+  }
+  if (field.type === "TableKey" && field.key?.type === "StringLiteral") {
+    return stringLitValue(field.key);
+  }
+  return null;
+}
+
+/**
+ * Resolve a Lua module path to an absolute filesystem path. Mono follows
+ * Lua's dot-to-slash convention: `require("lib.utils")` → `lib/utils.lua`,
+ * relative to the directory of the file doing the require.
+ */
+function resolveRequire(modPath, baseDir) {
+  const rel = modPath.replace(/\./g, "/") + ".lua";
+  const candidates = [
+    path.join(baseDir, rel),
+    path.join(baseDir, rel.replace(/\.lua$/, "/init.lua")),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+/**
+ * Recursively analyze a Lua module file and return the set of exported
+ * names. Cache prevents infinite recursion on cycles. Files that fail to
+ * parse or whose return shape is opaque map to null (caller treats as
+ * "exports unknown — allow any member access").
+ */
+function moduleExports(filepath, cache) {
+  if (cache.has(filepath)) return cache.get(filepath);
+  cache.set(filepath, null); // placeholder to break cycles
+  let ast;
+  try {
+    const src = fs.readFileSync(filepath, "utf8");
+    ast = luaparse.parse(src, { locations: false, comments: false, luaVersion: LUA_VERSION });
+  } catch {
+    return null;
+  }
+  const sym = collectSymbols(ast);
+  let exports = null;
+  if (sym.returnedTable && sym.tableModules.has(sym.returnedTable)) {
+    exports = sym.tableModules.get(sym.returnedTable);
+  } else if (sym.returnedTableLiteral) {
+    exports = sym.returnedTableLiteral;
+  }
+  cache.set(filepath, exports);
+  return exports;
+}
+
+/**
+ * Analyze a single Lua file and report unknown call sites against the given
+ * set of engine APIs.
+ *
+ * @param {string} filepath — absolute path to the Lua file
+ * @param {Set<string>} engineAPIs — names from docs/API.md
+ * @param {Map} [moduleCache] — pass a shared Map across files to dedupe work
+ * @returns {Array<{ line: number, name: string, kind: string }>}
+ */
+function findUnknownCalls(filepath, engineAPIs, moduleCache) {
+  const cache = moduleCache || new Map();
+  const src = fs.readFileSync(filepath, "utf8");
+  let ast;
+  try {
+    ast = luaparse.parse(src, { locations: true, comments: false, luaVersion: LUA_VERSION });
+  } catch (e) {
+    return [{ line: e.line || 0, name: "<parse error>", kind: "parse-error", msg: e.message }];
+  }
+  const sym = collectSymbols(ast);
+  const baseDir = path.dirname(filepath);
+
+  // Resolve required modules' exports up front.
+  const requireExports = new Map(); // varName → Set<string> | null
+  for (const [varName, modPath] of sym.requireBindings) {
+    const resolved = resolveRequire(modPath, baseDir);
+    if (!resolved) {
+      requireExports.set(varName, null); // unresolved: allow anything
+      continue;
+    }
+    requireExports.set(varName, moduleExports(resolved, cache));
+  }
+
+  const findings = [];
+  walk(ast, (node) => {
+    if (node.type !== "CallExpression"
+     && node.type !== "StringCallExpression"
+     && node.type !== "TableCallExpression") return;
+    const base = node.base;
+    if (!base) return;
+    const line = node.loc?.start?.line || 0;
+
+    if (base.type === "Identifier") {
+      const name = base.name;
+      if (sym.locals.has(name)) return;
+      if (sym.globals.has(name)) return;
+      if (engineAPIs.has(name)) return;
+      if (STDLIB_GLOBALS.has(name)) return;
+      if (LIFECYCLE_HOOKS.has(name)) return;
+      findings.push({ line, name: `${name}()`, kind: "unknown-call" });
+      return;
+    }
+
+    if (base.type === "MemberExpression" && base.indexer === ".") {
+      const modBase = base.base;
+      if (modBase.type !== "Identifier") return; // chained / complex base — skip
+      const mod = modBase.name;
+      const fn = base.identifier.name;
+
+      // require()-bound local: check against the module's exported names.
+      // Checked BEFORE the locals/globals fallback so a typo'd member call
+      // on a required module isn't silently allowed by virtue of being a
+      // local binding.
+      if (requireExports.has(mod)) {
+        const exports = requireExports.get(mod);
+        if (exports && !exports.has(fn)) {
+          findings.push({ line, name: `${mod}.${fn}()`, kind: "unknown-require-member" });
+        }
+        return;
+      }
+
+      // Locally-built module table (`local M = {}; function M.x() end`).
+      if (sym.tableModules.has(mod)) {
+        if (!sym.tableModules.get(mod).has(fn)) {
+          findings.push({ line, name: `${mod}.${fn}()`, kind: "unknown-member" });
+        }
+        return;
+      }
+
+      // Other user-declared local/global: trust it (full type tracking
+      // would be needed to verify members on arbitrary values).
+      if (sym.locals.has(mod) || sym.globals.has(mod)) return;
+
+      if (STDLIB_MODULES.has(mod)) {
+        if (!STDLIB[mod].includes(fn)) {
+          findings.push({ line, name: `${mod}.${fn}()`, kind: "unknown-stdlib-member" });
+        }
+        return;
+      }
+
+      findings.push({ line, name: `${mod}.${fn}()`, kind: "unknown-module" });
+    }
+    // base.type === "MemberExpression" with indexer ":" → method call.
+    // Skip: instance scope, would need full type tracking to verify.
+  });
+
+  return findings;
+}
+
+module.exports = {
+  collectSymbols,
+  moduleExports,
+  resolveRequire,
+  findUnknownCalls,
+  STDLIB,
+};

--- a/.claude/scripts/lib/lua-analysis.js
+++ b/.claude/scripts/lib/lua-analysis.js
@@ -102,16 +102,41 @@ function collectSymbols(ast) {
         }
         break;
       }
-      case "FunctionDeclaration": {
-        const id = node.identifier;
-        if (!id) break;
-        if (id.type === "Identifier") {
-          if (node.isLocal) locals.add(id.name);
-          else globals.add(id.name);
-        } else if (id.type === "MemberExpression"
-                && id.base.type === "Identifier") {
-          const mod = tableModules.get(id.base.name);
-          if (mod) mod.add(id.identifier.name);
+      case "FunctionDeclaration":
+      case "FunctionExpression": {
+        // Parameters (including method `self`) are locals scoped to the body.
+        // We use a flat scope so adding to the file-wide locals set is fine —
+        // it errs permissive but never produces a false positive.
+        if (Array.isArray(node.parameters)) {
+          for (const p of node.parameters) {
+            if (p.type === "Identifier") locals.add(p.name);
+          }
+        }
+        if (node.type === "FunctionDeclaration") {
+          const id = node.identifier;
+          if (!id) break;
+          if (id.type === "Identifier") {
+            if (node.isLocal) locals.add(id.name);
+            else globals.add(id.name);
+          } else if (id.type === "MemberExpression"
+                  && id.base.type === "Identifier") {
+            const mod = tableModules.get(id.base.name);
+            if (mod) mod.add(id.identifier.name);
+            // Method `function obj:foo(...)` adds an implicit `self` local.
+            if (id.indexer === ":") locals.add("self");
+          }
+        }
+        break;
+      }
+      case "ForNumericStatement": {
+        if (node.variable?.type === "Identifier") locals.add(node.variable.name);
+        break;
+      }
+      case "ForGenericStatement": {
+        if (Array.isArray(node.variables)) {
+          for (const v of node.variables) {
+            if (v.type === "Identifier") locals.add(v.name);
+          }
         }
         break;
       }
@@ -160,20 +185,38 @@ function fieldKeyName(field) {
 }
 
 /**
- * Resolve a Lua module path to an absolute filesystem path. Mono follows
- * Lua's dot-to-slash convention: `require("lib.utils")` → `lib/utils.lua`,
- * relative to the directory of the file doing the require.
+ * Resolve a Lua module path to an absolute filesystem path. Mono's runtime
+ * registers modules into package.preload using paths rooted at the **game
+ * root** (the directory containing main.lua), not at the directory of the
+ * file that calls require(). So `require("lib.utils")` from
+ * `scenes/play.lua` resolves to `<game-root>/lib/utils.lua`, not
+ * `scenes/lib/utils.lua`.
  */
-function resolveRequire(modPath, baseDir) {
+function resolveRequire(modPath, gameRoot) {
   const rel = modPath.replace(/\./g, "/") + ".lua";
   const candidates = [
-    path.join(baseDir, rel),
-    path.join(baseDir, rel.replace(/\.lua$/, "/init.lua")),
+    path.join(gameRoot, rel),
+    path.join(gameRoot, rel.replace(/\.lua$/, "/init.lua")),
   ];
   for (const c of candidates) {
     if (fs.existsSync(c)) return c;
   }
   return null;
+}
+
+/**
+ * Walk up from a Lua file's directory to find the game root — the closest
+ * ancestor that contains a main.lua. Falls back to the file's own dir.
+ */
+function findGameRoot(filepath) {
+  let dir = path.dirname(path.resolve(filepath));
+  while (true) {
+    if (fs.existsSync(path.join(dir, "main.lua"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.dirname(path.resolve(filepath));
 }
 
 /**
@@ -222,12 +265,12 @@ function findUnknownCalls(filepath, engineAPIs, moduleCache) {
     return [{ line: e.line || 0, name: "<parse error>", kind: "parse-error", msg: e.message }];
   }
   const sym = collectSymbols(ast);
-  const baseDir = path.dirname(filepath);
+  const gameRoot = findGameRoot(filepath);
 
   // Resolve required modules' exports up front.
   const requireExports = new Map(); // varName → Set<string> | null
   for (const [varName, modPath] of sym.requireBindings) {
-    const resolved = resolveRequire(modPath, baseDir);
+    const resolved = resolveRequire(modPath, gameRoot);
     if (!resolved) {
       requireExports.set(varName, null); // unresolved: allow anything
       continue;
@@ -305,6 +348,7 @@ module.exports = {
   collectSymbols,
   moduleExports,
   resolveRequire,
+  findGameRoot,
   findUnknownCalls,
   STDLIB,
 };

--- a/.claude/scripts/lib/lua-stdlib.json
+++ b/.claude/scripts/lib/lua-stdlib.json
@@ -1,0 +1,37 @@
+{
+  "_G": [
+    "assert", "collectgarbage", "dofile", "error", "getmetatable",
+    "ipairs", "load", "loadfile", "next", "pairs", "pcall", "print",
+    "rawequal", "rawget", "rawlen", "rawset", "require", "select",
+    "setmetatable", "tonumber", "tostring", "type", "warn", "xpcall"
+  ],
+  "math": [
+    "abs", "acos", "asin", "atan", "ceil", "cos", "deg", "exp",
+    "floor", "fmod", "huge", "log", "max", "maxinteger", "min",
+    "mininteger", "modf", "pi", "pow", "rad", "random", "randomseed",
+    "sin", "sqrt", "tan", "tointeger", "type", "ult"
+  ],
+  "string": [
+    "byte", "char", "dump", "find", "format", "gmatch", "gsub", "len",
+    "lower", "match", "pack", "packsize", "rep", "reverse", "sub",
+    "unpack", "upper"
+  ],
+  "table": [
+    "concat", "insert", "move", "pack", "remove", "sort", "unpack"
+  ],
+  "coroutine": [
+    "close", "create", "isyieldable", "resume", "running", "status",
+    "wrap", "yield"
+  ],
+  "utf8": [
+    "char", "charpattern", "codepoint", "codes", "len", "offset"
+  ],
+  "io": [
+    "close", "flush", "input", "lines", "open", "output", "read",
+    "stderr", "stdin", "stdout", "tmpfile", "type", "write"
+  ],
+  "os": [
+    "clock", "date", "difftime", "exit", "getenv", "remove", "rename",
+    "setlocale", "time", "tmpname"
+  ]
+}

--- a/.claude/scripts/mono-lint.js
+++ b/.claude/scripts/mono-lint.js
@@ -26,10 +26,12 @@ const ANSI = {
 };
 
 // --- Public API set ---
-// Shared helper parses runtime/engine.js on first use. Lazy-loaded so
-// `require()`ing this file from a non-CLI context (tests, other tools)
-// doesn't trigger file I/O at import time.
-const { loadPublicAPIs } = require("./lib/engine-apis");
+// Shared helpers parse runtime/engine.js (defensive-api-check) and
+// docs/API.md (unknown-api). Lazy-loaded so `require()`ing this file from
+// a non-CLI context (tests, other tools) doesn't trigger file I/O at
+// import time.
+const { loadPublicAPIs, loadAPIsFromMd } = require("./lib/engine-apis");
+const { findUnknownCalls } = require("./lib/lua-analysis");
 
 let _publicAPIs = null;
 function getPublicAPIs() {
@@ -45,6 +47,22 @@ function getPublicAPIs() {
   }
   return _publicAPIs;
 }
+
+let _apiMdNames = null;
+function getAPIMdNames() {
+  if (_apiMdNames === null) {
+    _apiMdNames = loadAPIsFromMd();
+    if (_apiMdNames.size === 0) {
+      console.warn(
+        "mono-lint: unknown-api skipped — could not load docs/API.md."
+      );
+    }
+  }
+  return _apiMdNames;
+}
+
+// Shared cache so a multi-file lint run only analyzes each required module once.
+const _moduleCache = new Map();
 
 // --- Rules ---
 // Each rule receives the full file content + per-line array.
@@ -326,6 +344,24 @@ rule("standard-structure", ({ file, content }) => {
     });
   }
   return out;
+});
+
+// Rule: call sites that aren't engine APIs, Lua stdlib, or locally defined.
+// Uses luaparse so we can distinguish locals/globals/required-module exports
+// from unknown calls — the regex rules above can't.
+rule("unknown-api", ({ file }) => {
+  if (!file) return [];
+  const apis = getAPIMdNames();
+  if (apis.size === 0) return [];
+  const findings = findUnknownCalls(file, apis, _moduleCache);
+  return findings.map(f => ({
+    line: f.line,
+    severity: "error",
+    rule: "unknown-api",
+    msg: f.kind === "parse-error"
+      ? `lua parse failed: ${f.msg}`
+      : `${f.name} is not an API.md entry, Lua stdlib, or a local/required name (${f.kind})`,
+  }));
 });
 
 // btnp() before go() — should use btnr() for scene transitions.

--- a/.claude/scripts/mono-lint.js
+++ b/.claude/scripts/mono-lint.js
@@ -356,10 +356,14 @@ rule("unknown-api", ({ file }) => {
   const findings = findUnknownCalls(file, apis, _moduleCache);
   return findings.map(f => ({
     line: f.line,
-    severity: "error",
+    // Parse errors degrade to info — luaparse caps at 5.3 grammar so
+    // valid Lua 5.4 syntax (`<const>`, `<close>`) trips it. info doesn't
+    // increment the warning/error counters, so the lint passes; the user
+    // still sees a note that the rule was skipped for that file.
+    severity: f.kind === "parse-error" ? "info" : "error",
     rule: "unknown-api",
     msg: f.kind === "parse-error"
-      ? `lua parse failed: ${f.msg}`
+      ? `unknown-api skipped — luaparse rejected the file (likely Lua 5.4 syntax): ${f.msg}`
       : `${f.name} is not an API.md entry, Lua stdlib, or a local/required name (${f.kind})`,
   }));
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "luaparse": "^0.3.1",
         "luau-web": "^1.4.0",
         "pngjs": "^7.0.0",
         "wasmoon": "^1.16.0"
@@ -729,6 +730,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/luaparse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/luaparse/-/luaparse-0.3.1.tgz",
+      "integrity": "sha512-b21h2bFEbtGXmVqguHogbyrMAA0wOHyp9u/rx+w6Yc9pW1t9YjhGUsp87lYcp7pFRqSWN/PhFkrdIqKEUzRjjQ==",
+      "license": "MIT",
+      "bin": {
+        "luaparse": "bin/luaparse"
       }
     },
     "node_modules/luau-web": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/monogame-storage/mono#readme",
   "dependencies": {
+    "luaparse": "^0.3.1",
     "luau-web": "^1.4.0",
     "pngjs": "^7.0.0",
     "wasmoon": "^1.16.0"


### PR DESCRIPTION
## Summary

Adds a strict whitelist linter rule to \`mono-lint.js\`: any function call that isn't an entry in \`docs/API.md\`, a Lua 5.4 stdlib name, a locally defined symbol, or an export of a \`require()\`'d module is reported as an error.

The shift in posture: instead of relying on \`docs/AI-PITFALLS.md\` to enumerate AI mistakes after the fact (a blocklist), this rule constrains generated code to the engine's actual surface (an allowlist). Drift becomes a static error.

## What's new

- **\`.claude/scripts/lib/lua-stdlib.json\`** — Lua 5.4 stdlib whitelist (basic + math/string/table/coroutine/utf8/io/os).
- **\`.claude/scripts/lib/lua-analysis.js\`** — luaparse-based AST analysis: collectSymbols, moduleExports, findUnknownCalls. Recursively resolves \`require()\` chains so member calls like \`config.foo()\` validate against the target file's exports. Tracks the \`local M = {}; function M.x() end\` module pattern.
- **\`engine-apis.js\`** — adds \`loadAPIsFromMd()\` so the rule reads the canonical surface from \`docs/API.md\` (covers both \`engine.js\` and \`engine-bindings.js\` registrations, plus the shadow-stub'd Lua wrappers).
- **\`mono-lint.js\`** — integrates as the new \`unknown-api\` rule. Shares a module cache across files in multi-file lint runs.

Lifecycle hook names (\`_init\`, \`_start\`, \`_ready\`, \`_update\`, \`_draw\`) are whitelisted globally so game code can recursively call them without local declarations.

## Test plan

- [x] All 10 existing demos lint clean (\`bounce, bubble, clock, dodge, invaders, motion, paint, pong, scene-test, tiltmaze\`)
- [x] Synthetic test catches:
  - typo'd engine API (\`rectfill()\` → unknown-call)
  - unknown stdlib member (\`math.bogus()\` → unknown-stdlib-member)
  - undefined module (\`unknown_mod.foo()\` → unknown-module)
  - undefined required-module export (\`local lib = require("lib"); lib.bogus()\` → unknown-require-member)
- [x] Lua 5.3 grammar feed handles \`goto/::label::\` (was breaking on bubble's \`goto skip_pop\`)
- [x] No new dependencies beyond \`luaparse\` (MIT, no native deps)

## Future scope (not this PR)

- AI-PITFALLS.md trim: the API-surface portion (\`stop() doesn't exist\`, \`btn() returns boolean\`, etc.) is now redundant with this rule. The Lua/Wasmoon idiom portion (\`rnd() in draw()\`, forward refs, null returns, diagonal normalization) stays — those are semantics, not API surface.
- Tracking \`go("scene")\` cross-file (currently only \`require()\` traverses).
- Method-call (\`obj:method\`) tracking would need full type inference; currently skipped.