### PR TITLE
refactor(ai): rename "AI Assistant" → "Cosmi"

### DIFF
--- a/dev/css/editor.css
+++ b/dev/css/editor.css
@@ -1654,7 +1654,9 @@
   gap: 10px;
 }
 .devsettings-item-left svg { width: 16px; height: 16px; color: #aaa; }
+.devsettings-item-text { display: flex; flex-direction: column; gap: 2px; }
 .devsettings-item-label { font-size: 12px; }
+.devsettings-item-sub { font-size: 10px; color: #888; }
 .devsettings-item-arrow { color: #555; font-size: 14px; }
 .devsettings-signout {
   width: 100%;

--- a/dev/index.html
+++ b/dev/index.html
@@ -192,7 +192,7 @@
           </div>
         </div>
         <div class="game-section">
-          <span class="game-section-label">AI Assistant</span>
+          <span class="game-section-label">Cosmi</span>
           <div class="game-provider-row">
             <span class="game-provider-name" id="game-provider-name">Default</span>
             <button class="game-provider-link" id="btn-game-aip">Change</button>
@@ -223,11 +223,11 @@
     </div>
   </div>
 
-  <!-- ── AI Assistant / Connections View ── -->
+  <!-- ── Cosmi / Connections View ── -->
   <div id="view-ai-providers" class="view">
     <div class="aip-topbar">
       <button id="btn-aip-back">‹</button>
-      <span>AI Assistant</span>
+      <span>Cosmi</span>
     </div>
     <div class="aip-content">
       <div class="aip-passphrase-section" id="aip-mk-section">
@@ -328,7 +328,7 @@
       <div class="devsettings-item" id="btn-ai-providers">
         <div class="devsettings-item-left">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><circle cx="12" cy="5" r="4"/></svg>
-          <span class="devsettings-item-label">AI Assistant</span>
+          <span class="devsettings-item-label">Cosmi</span>
         </div>
         <span class="devsettings-item-arrow">›</span>
       </div>

--- a/dev/index.html
+++ b/dev/index.html
@@ -328,7 +328,10 @@
       <div class="devsettings-item" id="btn-ai-providers">
         <div class="devsettings-item-left">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><circle cx="12" cy="5" r="4"/></svg>
-          <span class="devsettings-item-label">Cosmi</span>
+          <div class="devsettings-item-text">
+            <span class="devsettings-item-label">Cosmi</span>
+            <span class="devsettings-item-sub">AI Assistant</span>
+          </div>
         </div>
         <span class="devsettings-item-arrow">›</span>
       </div>

--- a/dev/js/editor-ai.js
+++ b/dev/js/editor-ai.js
@@ -396,7 +396,7 @@ async function sendAgent(connection, msg, chat) {
   // navigation, multi-tab edit). Bail with a clear error instead of
   // crashing on `connection.provider`.
   if (!connection?.provider || !connection?.model || !connection?.apiKey) {
-    throw new Error("Connection is invalid — re-pick or re-add it in Settings → AI Assistant.");
+    throw new Error("Connection is invalid — re-pick or re-add it in Settings → Cosmi.");
   }
   const providerId = connection.provider;
   const model = connection.model;
@@ -678,7 +678,7 @@ export async function sendMessage(autoMsg) {
   if (!selectedValue.startsWith("provider:")) {
     const chatEl = document.getElementById("editor-chat");
     chatEl.innerHTML += errorCard(
-      "Register a Connection in Settings → AI Assistant, then pick it from the pill above to enable chat.",
+      "Register a Connection in Settings → Cosmi, then pick it from the pill above to enable chat.",
       "NO CONNECTION",
       false,
     );

--- a/dev/js/state.js
+++ b/dev/js/state.js
@@ -20,7 +20,7 @@ export const state = {
   gameRunning: false,
   sessionTokens: { prompt: 0, completion: 0, total: 0 },
 
-  // AI Assistant — user's Connections: { id, alias, provider, model,
+  // Cosmi — user's Connections: { id, alias, provider, model,
   // apiKey, baseUrl?, isDefault }. `provider` keys into the server's
   // PROVIDER_CATALOG (fetched via /config); `model` is an id chosen
   // from a live /models query (or manually typed as a fallback).


### PR DESCRIPTION
## Summary

- UI 기능 이름 `AI Assistant` → `Cosmi`로 교체 (Code Smith 줄임 + Copilot 패턴)
- 변경 대상: 화면 라벨, 안내 메시지, 코드 주석 (총 7곳)
- 변경 제외: mono-api 백엔드 페르소나(`Mono`)는 별개 개념이라 그대로 유지. 내부 식별자(`.ai-chat`, `#editor-chat`)도 사용자 노출 X라 보존. `docs/AI-PITFALLS.md` 등의 일반 "AI assistants" 표현(Claude/Codex 등 외부 도구 지칭)도 의도적 보존

## 왜 Cosmi인가

| | 영문 | 한글 | 비고 |
|---|---|---|---|
| AI Assistant | 12 | - | 일반어, 다른 AI 시스템과 혼동 |
| Codesmith | 8 | 5 | 정확하지만 김 |
| Cosmith | 7 | 4 | 절충안 |
| **Cosmi** | **5** | **3** | **선택** — co-(함께) + smi(smith) |

## Test plan

- [ ] 에디터 진입 → 게임 섹션에서 "Cosmi" 라벨 표시 확인
- [ ] Settings(개발자 설정) → "Cosmi" 항목으로 진입되는지 확인
- [ ] AI Connections 화면 상단 라벨이 "Cosmi"로 표시되는지 확인
- [ ] Connection 미선택 상태에서 채팅 시도 → "Settings → Cosmi" 안내 메시지 표시 확인
- [ ] Connection 무효 상태 에러 메시지에 "Settings → Cosmi" 표기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)