### PR TITLE
feat(eval): LLM judge — score generated games against spec

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -71,3 +71,40 @@ jobs:
             fi
           done
           exit $fail
+
+  # Cosmi (the Cloudflare Worker that runs the chat agent + lint
+  # pipeline) lives in its own subtree with its own package.json and
+  # wrangler config. Validating it here catches:
+  #   - syntax / import regressions in the worker source
+  #   - lint regressions (api-lint, engine-primitive guard, gameId guard)
+  #   - prompt / tool drift (agent-prompt.test.mjs)
+  #   - wrangler.toml breakage (e.g. assets misconfig that broke deploy
+  #     earlier)
+  # Runs in parallel with the mono-side validate job above.
+  validate-cosmi:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cosmi
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: cosmi/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: JS syntax check
+        run: npm run check
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Wrangler dry-run deploy
+        run: npx --yes wrangler@latest deploy --dry-run --outdir dist

--- a/cosmi/eval/README.md
+++ b/cosmi/eval/README.md
@@ -41,6 +41,8 @@ KIMI_API_KEY=sk-... node run-battery.mjs --filter brick
 | `KIMI_BASE`    | `https://api.moonshot.ai`     | for relays                              |
 | `MONO_REPO`    | `../..`                       | path to the mono repo root (API.md + runner) |
 | `MAX_ITER`     | `20`                          | agent loop cap, mirrors prod            |
+| `KIMI_JUDGE_MODEL` | same as `KIMI_MODEL`      | model used for the post-run intent judge |
+| `NO_JUDGE`     | `0`                           | set to `1` to skip the judge phase entirely |
 
 ## What gets recorded
 

--- a/cosmi/eval/harness.mjs
+++ b/cosmi/eval/harness.mjs
@@ -288,13 +288,17 @@ async function judgeOutput({ spec, files, smoke, log }) {
       body: JSON.stringify({
         // temperature is not set — KIMI k2.6 currently rejects any
         // value other than 1, and the rubric is concrete enough that
-        // determinism isn't critical.
+        // determinism isn't critical. max_tokens matches the agent
+        // loop budget — k2.6 spends 4-6k tokens on internal reasoning
+        // for a long file review and returns an empty content if it
+        // hits the cap mid-thought (observed: 2/4 judge calls came
+        // back blank at 4096).
         model: KIMI_JUDGE_MODEL,
         messages: [
           { role: "system", content: "You output only a single JSON object." },
           { role: "user", content: judgePrompt },
         ],
-        max_tokens: 4096,
+        max_tokens: 8192,
       }),
     });
     if (!res.ok) {

--- a/cosmi/eval/harness.mjs
+++ b/cosmi/eval/harness.mjs
@@ -43,6 +43,14 @@ const MONO_RUNNER = path.join(MONO_REPO, "dev/headless/mono-runner.js");
 const KIMI_API_KEY = process.env.KIMI_API_KEY;
 const KIMI_MODEL = process.env.KIMI_MODEL || "kimi-k2.6";
 const KIMI_BASE = process.env.KIMI_BASE || "https://api.moonshot.ai";
+// The judge defaults to the same model — fine for first-pass scoring
+// since the judge prompt lists explicit rubric items, leaving little
+// room for self-flattery. Override with KIMI_JUDGE_MODEL=kimi-k2.5
+// (etc.) to cross-check or save cost.
+const KIMI_JUDGE_MODEL = process.env.KIMI_JUDGE_MODEL || KIMI_MODEL;
+// Set NO_JUDGE=1 to skip the judge phase entirely (useful when
+// iterating on lint logic — saves ~30s and ~5k tokens per spec).
+const SKIP_JUDGE = process.env.NO_JUDGE === "1";
 // Override only when probing model behaviour at extreme depths;
 // default mirrors the prod Worker so harness numbers match what
 // users actually hit.
@@ -223,6 +231,101 @@ async function smokeTest(r2) {
   }
 }
 
+// LLM judge — score the produced game against the spec on a 0-10
+// scale. Smoke says "did it boot for 40 frames"; the judge says "did
+// it actually do what was asked". Deliberately uses a separate
+// session from the agent so the judge has no memory of the model's
+// own writes / reasoning.
+async function judgeOutput({ spec, files, smoke, log }) {
+  if (SKIP_JUDGE) return { skipped: true };
+  if (files.length === 0) {
+    return {
+      score: 0,
+      summary: "Agent produced no files.",
+      missing: ["any output"],
+      present: [],
+    };
+  }
+
+  const fileBlock = files
+    .map(({ name, content }) => `### ${name}\n\`\`\`lua\n${content}\n\`\`\``)
+    .join("\n\n");
+  const smokeBlock = smoke.passed
+    ? `Smoke test PASSED (booted + ran 40 frames cleanly).`
+    : `Smoke test FAILED (exit ${smoke.code}). Stderr: ${(smoke.stderr || "").slice(0, 400)}`;
+
+  const judgePrompt = [
+    "You are reviewing a Mono fantasy console game produced by an AI agent against a user spec.",
+    "Mono runs Lua 5.4, 160x120, up to 16 grayscale shades. The agent had access to docs/API.md.",
+    "",
+    "Score 0-10 on how well the produced code FULFILS THE SPEC, not on code style.",
+    "Rubric:",
+    "- 0-3: skeleton only or missing major features",
+    "- 4-6: most features present but with significant gaps or bugs",
+    "- 7-8: all primary features present, minor polish or edge-case gaps",
+    "- 9-10: spec fully realized including edge cases (game-over, restart, etc.)",
+    "",
+    "Reply with ONLY a JSON object, no prose, no code fences:",
+    '{ "score": <0-10>, "summary": "<one sentence>", "present": ["<feature>", ...], "missing": ["<feature>", ...] }',
+    "",
+    "## Spec",
+    spec.trim(),
+    "",
+    "## Smoke",
+    smokeBlock,
+    "",
+    "## Files",
+    fileBlock,
+  ].join("\n");
+
+  try {
+    const res = await fetch(`${KIMI_BASE.replace(/\/$/, "")}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${KIMI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        // temperature is not set — KIMI k2.6 currently rejects any
+        // value other than 1, and the rubric is concrete enough that
+        // determinism isn't critical.
+        model: KIMI_JUDGE_MODEL,
+        messages: [
+          { role: "system", content: "You output only a single JSON object." },
+          { role: "user", content: judgePrompt },
+        ],
+        max_tokens: 4096,
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return { error: `judge ${res.status}: ${body.slice(0, 300)}` };
+    }
+    const data = await res.json();
+    log.judgeTokens = {
+      input: data.usage?.prompt_tokens || 0,
+      output: data.usage?.completion_tokens || 0,
+    };
+    const text = data.choices?.[0]?.message?.content || "";
+    // Strip ```json fences if the model adds them despite instructions.
+    const cleaned = text.trim().replace(/^```(?:json)?\s*/i, "").replace(/```\s*$/i, "");
+    try {
+      const parsed = JSON.parse(cleaned);
+      const score = Number(parsed.score);
+      return {
+        score: Number.isFinite(score) ? Math.max(0, Math.min(10, score)) : null,
+        summary: typeof parsed.summary === "string" ? parsed.summary : "",
+        present: Array.isArray(parsed.present) ? parsed.present : [],
+        missing: Array.isArray(parsed.missing) ? parsed.missing : [],
+      };
+    } catch {
+      return { error: "judge response was not JSON", raw: text.slice(0, 500) };
+    }
+  } catch (e) {
+    return { error: e?.message || String(e) };
+  }
+}
+
 export async function runOne(specPath) {
   if (!KIMI_API_KEY) throw new Error("KIMI_API_KEY env var is required");
   const spec = await fs.readFile(specPath, "utf8");
@@ -251,13 +354,16 @@ export async function runOne(specPath) {
   }
   const elapsedMs = Date.now() - t0;
   const smoke = await smokeTest(r2);
+  const filesFull = [...r2.files.entries()].map(([name, content]) => ({ name, content }));
+  const judge = await judgeOutput({ spec, files: filesFull, smoke, log });
 
   return {
     spec: path.basename(specPath, path.extname(specPath)),
     elapsedMs,
-    files: [...r2.files.entries()].map(([name, content]) => ({ name, size: content.length })),
+    files: filesFull.map(({ name, content }) => ({ name, size: content.length })),
     log,
     smoke,
+    judge,
   };
 }
 

--- a/cosmi/eval/run-battery.mjs
+++ b/cosmi/eval/run-battery.mjs
@@ -61,7 +61,11 @@ function fmtRow(r) {
   const tokIn = r.log?.tokens?.input ?? 0;
   const tokOut = r.log?.tokens?.output ?? 0;
   const smoke = r.smoke?.passed ? "PASS" : `FAIL${r.smoke?.code != null ? `(${r.smoke.code})` : ""}`;
-  return `${r.spec.padEnd(8)} | iters ${String(iters).padStart(2)} | writes ${String(writes).padStart(2)} | rej ${String(rejs).padStart(2)} | smoke ${smoke.padEnd(8)} | ${sec}s | tok ${tokIn}/${tokOut}`;
+  let judge = "  -";
+  if (r.judge?.skipped) judge = "skip";
+  else if (typeof r.judge?.score === "number") judge = `${r.judge.score}/10`;
+  else if (r.judge?.error) judge = " err";
+  return `${r.spec.padEnd(8)} | iters ${String(iters).padStart(2)} | writes ${String(writes).padStart(2)} | rej ${String(rejs).padStart(2)} | smoke ${smoke.padEnd(8)} | judge ${judge.padEnd(5)} | ${sec}s | tok ${tokIn}/${tokOut}`;
 }
 
 async function main() {
@@ -78,7 +82,8 @@ async function main() {
     const name = path.basename(specPath, path.extname(specPath));
     console.error(`  → start: ${name}`);
     const r = await runOne(specPath);
-    console.error(`  ✓ done:  ${name} (${(r.elapsedMs / 1000).toFixed(1)}s, smoke=${r.smoke.passed ? "pass" : "fail"})`);
+    const score = typeof r.judge?.score === "number" ? `, judge=${r.judge.score}/10` : "";
+    console.error(`  ✓ done:  ${name} (${(r.elapsedMs / 1000).toFixed(1)}s, smoke=${r.smoke.passed ? "pass" : "fail"}${score})`);
     const out = path.join(RESULTS_DIR, `${name}-${ts}.json`);
     await fs.writeFile(out, JSON.stringify(r, null, 2));
     return r;
@@ -91,7 +96,16 @@ async function main() {
   }
 
   const passed = results.filter((r) => r?.smoke?.passed).length;
-  console.log(`\n${passed}/${results.length} smoke tests passed`);
+  const scored = results.filter((r) => typeof r?.judge?.score === "number");
+  const avgScore = scored.length
+    ? (scored.reduce((s, r) => s + r.judge.score, 0) / scored.length).toFixed(1)
+    : "n/a";
+  console.log(`\n${passed}/${results.length} smoke tests passed · avg judge score: ${avgScore}/10 (${scored.length} scored)`);
+  // Per-spec judge summaries — quick read on what's missing.
+  for (const r of scored) {
+    const miss = (r.judge.missing || []).slice(0, 3).join(", ");
+    console.log(`  ${r.spec}: ${r.judge.summary}${miss ? ` — missing: ${miss}` : ""}`);
+  }
   process.exit(passed === results.length ? 0 : 1);
 }
 


### PR DESCRIPTION
## Summary

Adds a post-run LLM judge phase to the eval harness. Smoke test answers "did it boot for 40 frames"; the judge answers "did it actually do what the spec asked".

### Why

Without the judge, the battery's headline metric is "5/5 smoke pass" — but a game that prints a black screen for 40 frames also smoke-passes. The user reported this as the gap that prevents real self-verification of Cosmi.

### How

After the agent stops and smoke runs, harness submits `(spec, generated files, smoke result)` to `KIMI_JUDGE_MODEL` (defaults to the agent model) with a 0-10 rubric. Returns JSON `{ score, summary, present, missing }`. Judge runs in a fresh session — no agent reasoning bled in — so scores read like a reviewer cracking the code cold.

### Validation

`brick.txt` baseline:
```
score: 5
summary: "Core brick-breaking mechanics work but GAME OVER / YOU WIN scenes and START restart are missing."
present: paddle movement, ball physics, brick collision, score, ...
missing: game-over screen, win screen, restart key
```

Reflects the staging rule's expected partial output — exactly the signal the iteration loop needs.

### What's in this PR

- `cosmi/eval/harness.mjs`: `judgeOutput()` + `result.judge` field. `NO_JUDGE=1` skips entirely; `KIMI_JUDGE_MODEL` overrides the judge model independent of the agent model.
- `cosmi/eval/run-battery.mjs`: summary table gains a judge column; per-spec missing-features list printed at end; average score across the battery.
- `cosmi/eval/README.md`: documents the new env vars.

## Test plan

- [ ] `cd cosmi/eval && KIMI_API_KEY=... node harness.mjs specs/brick.txt` — verify `result.judge` populated
- [ ] `node run-battery.mjs --parallel 2` — verify summary table + per-spec rationale lines
- [ ] `NO_JUDGE=1 node harness.mjs specs/brick.txt` — verify judge skipped without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)