### PR TITLE
feat(save): CloudBackend — per-uid R2 cloud sync for logged-in players

### DIFF
--- a/cosmi/src/index.js
+++ b/cosmi/src/index.js
@@ -110,6 +110,18 @@ export default {
         return await handleListLintRejects(env, uid, url);
       }
 
+      // ── Save endpoints (cloud-save / data_*) ──
+      const saveMatch = url.pathname.match(/^\/save\/([^/]+)$/);
+      if (saveMatch) {
+        const cartId = decodeURIComponent(saveMatch[1]);
+        const badCart = validateCartId(cartId);
+        if (badCart) return json(400, { error: badCart });
+        if (request.method === "GET")    return await handleSaveGet(env, uid, cartId);
+        if (request.method === "PUT")    return await handleSavePut(env, uid, cartId, request);
+        if (request.method === "DELETE") return await handleSaveDelete(env, uid, cartId);
+        return json(405, { error: "Method not allowed" });
+      }
+
       // ── File endpoints ──
       const match = url.pathname.match(/^\/games\/([^/]+)\/files(?:\/(.+))?$/);
       if (!match) return json(404, { error: "Not found" });
@@ -550,7 +562,8 @@ async function deleteFile(env, key) {
 // real time. File I/O goes straight to R2.
 
 import { lintEnginePrimitiveOverwrite, lintDataKeys } from "./lib/lint.js";
-import { validateAgentPath, validateGameId } from "./lib/path.js";
+import { validateAgentPath, validateGameId, validateCartId } from "./lib/path.js";
+import { handleSaveGet, handleSavePut, handleSaveDelete } from "./save-handlers.js";
 import { extractApiWhitelist, lintApiCompliance, collectFileDefinedNames } from "./lib/api-lint.js";
 import { AGENT_TOOLS, AGENT_MAX_ITER, buildAgentSystemPrompt } from "./lib/agent-prompt.js";
 

--- a/cosmi/src/lib/path.js
+++ b/cosmi/src/lib/path.js
@@ -25,3 +25,17 @@ export function validateGameId(g) {
   }
   return null;
 }
+
+// Reject malformed cartId values before they hit R2 as a save key. cartId
+// is a richer namespace than gameId — it carries scheme prefixes like
+// "demo:bounce" or "pkg:com.foo.bar" — but path-traversal characters
+// (slash, backslash, dot, NUL, whitespace) must be rejected. The colon
+// is allowed because the only place cartIds appear is *inside* a path
+// segment, never as a delimiter on the worker side.
+export function validateCartId(s) {
+  if (typeof s !== "string" || !s) return "cartId required";
+  if (!/^[a-zA-Z0-9:_-]{1,80}$/.test(s)) {
+    return "must match /^[a-zA-Z0-9:_-]{1,80}$/";
+  }
+  return null;
+}

--- a/cosmi/src/save-handlers.js
+++ b/cosmi/src/save-handlers.js
@@ -1,0 +1,74 @@
+// Cloud save handlers. Pure functions over (env, uid, cartId[, request]) →
+// Response. Extracted from index.js's route table so they can be tested
+// without booting a wrangler runtime. Each handler is the leaf called
+// after auth + cartId validation in the main fetch handler.
+//
+// R2 record shape: { version: 1, bucket: <object>, updated_at: <unix_ms> }
+// The wrapper is opaque to the client; GET strips it down to { bucket }.
+
+const R2_PREFIX = "save/";
+const MAX_BODY_BYTES = 70_000;   // ~64KB JSON + headroom; defense in depth
+
+function r2Key(uid, cartId) {
+  return R2_PREFIX + uid + "/" + cartId;
+}
+
+function json(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": "Authorization, Content-Type",
+    },
+  });
+}
+
+function noContent() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": "Authorization, Content-Type",
+    },
+  });
+}
+
+export async function handleSaveGet(env, uid, cartId) {
+  const obj = await env.BUCKET.get(r2Key(uid, cartId));
+  if (!obj) return json(404, { error: "Not found" });
+  const text = await obj.text();
+  let parsed;
+  try { parsed = JSON.parse(text); } catch { parsed = null; }
+  // If the stored record is corrupt or shape-wrong, treat as empty bucket
+  // rather than 500. The client's mirror is the source of truth here;
+  // a successful 200 lets the client overwrite on next save.
+  const bucket = (parsed && typeof parsed === "object" && parsed.bucket
+                  && typeof parsed.bucket === "object" && !Array.isArray(parsed.bucket))
+    ? parsed.bucket : {};
+  return json(200, { bucket });
+}
+
+export async function handleSavePut(env, uid, cartId, request) {
+  const lenHeader = request.headers.get("Content-Length");
+  const len = lenHeader ? parseInt(lenHeader, 10) : 0;
+  if (len > MAX_BODY_BYTES) return json(413, { error: "body too large" });
+  let body;
+  try { body = await request.json(); }
+  catch { return json(400, { error: "invalid JSON" }); }
+  if (!body || typeof body !== "object") return json(400, { error: "body must be an object" });
+  const bucket = body.bucket;
+  if (!bucket || typeof bucket !== "object" || Array.isArray(bucket)) {
+    return json(400, { error: "body.bucket must be a plain object" });
+  }
+  const record = { version: 1, bucket, updated_at: Date.now() };
+  await env.BUCKET.put(r2Key(uid, cartId), JSON.stringify(record));
+  return noContent();
+}
+
+export async function handleSaveDelete(env, uid, cartId) {
+  await env.BUCKET.delete(r2Key(uid, cartId));
+  return noContent();
+}

--- a/cosmi/src/save-handlers.js
+++ b/cosmi/src/save-handlers.js
@@ -52,11 +52,21 @@ export async function handleSaveGet(env, uid, cartId) {
 }
 
 export async function handleSavePut(env, uid, cartId, request) {
+  // Fast-path 413 from Content-Length to avoid buffering oversized requests.
+  // Non-numeric / missing headers fall through to the post-parse byte check
+  // below — Content-Length alone is spoofable, so it's a hint, not the gate.
   const lenHeader = request.headers.get("Content-Length");
-  const len = lenHeader ? parseInt(lenHeader, 10) : 0;
-  if (len > MAX_BODY_BYTES) return json(413, { error: "body too large" });
+  const declaredLen = lenHeader ? parseInt(lenHeader, 10) : 0;
+  if (declaredLen > MAX_BODY_BYTES) return json(413, { error: "body too large" });
+  // Read the body as text first so we can measure actual bytes before
+  // JSON.parse runs — a 5MB body with `Content-Length: 0` shouldn't slip
+  // through. text() respects CF Workers' global 100MB request cap.
+  let raw;
+  try { raw = await request.text(); }
+  catch { return json(400, { error: "invalid body" }); }
+  if (raw.length > MAX_BODY_BYTES) return json(413, { error: "body too large" });
   let body;
-  try { body = await request.json(); }
+  try { body = JSON.parse(raw); }
   catch { return json(400, { error: "invalid JSON" }); }
   if (!body || typeof body !== "object") return json(400, { error: "body must be an object" });
   const bucket = body.bucket;

--- a/cosmi/src/save-handlers.js
+++ b/cosmi/src/save-handlers.js
@@ -55,6 +55,14 @@ export async function handleSavePut(env, uid, cartId, request) {
   // Fast-path 413 from Content-Length to avoid buffering oversized requests.
   // Non-numeric / missing headers fall through to the post-parse byte check
   // below — Content-Length alone is spoofable, so it's a hint, not the gate.
+  //
+  // Known limitation: an authenticated client that omits Content-Length and
+  // streams up to 100MB (CF Workers' platform cap) burns isolate CPU/memory
+  // until request.text() resolves. The post-parse check rejects after
+  // buffering. Streaming inspection via request.body.getReader() would
+  // abort earlier — flagged as BETA follow-up. Bounded by verifyAuth, so
+  // not a public DoS vector, but a single bad authenticated client can
+  // chew through Worker time. Acceptable trade-off in ALPHA.
   const lenHeader = request.headers.get("Content-Length");
   const declaredLen = lenHeader ? parseInt(lenHeader, 10) : 0;
   if (declaredLen > MAX_BODY_BYTES) return json(413, { error: "body too large" });

--- a/cosmi/test/path.test.mjs
+++ b/cosmi/test/path.test.mjs
@@ -2,7 +2,7 @@
 // untrusted — these vectors must never reach R2 key concatenation.
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { validateAgentPath, validateGameId } from "../src/lib/path.js";
+import { validateAgentPath, validateGameId, validateCartId } from "../src/lib/path.js";
 
 describe("validateAgentPath", () => {
   it("accepts a plain filename", () => {
@@ -88,5 +88,46 @@ describe("validateGameId", () => {
 
   it("accepts a 64-char id at the boundary", () => {
     assert.equal(validateGameId("a".repeat(64)), null);
+  });
+});
+
+describe("validateCartId", () => {
+  it("accepts plain alphanumerics", () => {
+    assert.equal(validateCartId("game42"), null);
+  });
+
+  it("accepts colons and underscores and hyphens", () => {
+    assert.equal(validateCartId("demo:bounce"), null);
+    assert.equal(validateCartId("pkg:com.foo"), "must match /^[a-zA-Z0-9:_-]{1,80}$/"); // dot rejected
+    assert.equal(validateCartId("pkg:com_foo"), null);
+    assert.equal(validateCartId("hi-score_v2"), null);
+  });
+
+  it("accepts boundary length 80", () => {
+    assert.equal(validateCartId("a".repeat(80)), null);
+  });
+
+  it("rejects empty / null / non-string", () => {
+    assert.match(validateCartId(""), /required/);
+    assert.match(validateCartId(null), /required/);
+    assert.match(validateCartId(undefined), /required/);
+    assert.match(validateCartId(42), /required/);
+  });
+
+  it("rejects > 80 chars", () => {
+    assert.match(validateCartId("a".repeat(81)), /must match/);
+  });
+
+  it("rejects path traversal vectors", () => {
+    assert.match(validateCartId("../foo"), /must match/);
+    assert.match(validateCartId("foo/bar"), /must match/);
+    assert.match(validateCartId("foo\\bar"), /must match/);
+    assert.match(validateCartId(".."), /must match/);
+  });
+
+  it("rejects whitespace and control chars", () => {
+    assert.match(validateCartId("foo bar"), /must match/);
+    assert.match(validateCartId("foo\tbar"), /must match/);
+    assert.match(validateCartId("foo\0bar"), /must match/);
   });
 });

--- a/cosmi/test/save-endpoint.test.mjs
+++ b/cosmi/test/save-endpoint.test.mjs
@@ -107,6 +107,27 @@ describe("handleSavePut", () => {
     const res = await handleSavePut(env, "user1", "demo:bounce", req);
     assert.equal(res.status, 400);
   });
+
+  it("returns 400 when bucket is a scalar (number / string / null)", async () => {
+    for (const bad of [5, "hi", null, true]) {
+      const req = jsonBodyRequest("PUT", { bucket: bad });
+      const res = await handleSavePut(env, "user1", "demo:bounce", req);
+      assert.equal(res.status, 400, `bucket=${JSON.stringify(bad)} should be 400`);
+    }
+  });
+
+  it("returns 413 when actual body bytes exceed cap even with Content-Length spoofed to 0", async () => {
+    // Build a real oversize JSON body but lie in the header. The post-parse
+    // byte check should still reject — Content-Length is a hint, not the gate.
+    const big = "x".repeat(70_001);
+    const req = new Request("https://x/save/test", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", "Content-Length": "0" },
+      body: JSON.stringify({ bucket: { k: big } }),
+    });
+    const res = await handleSavePut(env, "user1", "demo:bounce", req);
+    assert.equal(res.status, 413);
+  });
 });
 
 describe("handleSaveDelete", () => {

--- a/cosmi/test/save-endpoint.test.mjs
+++ b/cosmi/test/save-endpoint.test.mjs
@@ -1,0 +1,127 @@
+// Cloud-save worker route tests. Drives the helpers directly with a
+// fake R2 BUCKET so we don't need a wrangler runtime.
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { handleSaveGet, handleSavePut, handleSaveDelete } from "../src/save-handlers.js";
+
+function makeFakeR2() {
+  const map = new Map();
+  return {
+    map,
+    get: async (key) => {
+      const v = map.get(key);
+      if (v == null) return null;
+      return { text: async () => v };
+    },
+    put: async (key, body) => { map.set(key, body); },
+    delete: async (key) => { map.delete(key); },
+  };
+}
+function makeEnv() { return { BUCKET: makeFakeR2() }; }
+function jsonBodyRequest(method, body, headers = {}) {
+  return new Request("https://x/save/test", {
+    method,
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("handleSaveGet", () => {
+  let env;
+  beforeEach(() => { env = makeEnv(); });
+
+  it("returns 404 when the entry is missing", async () => {
+    const res = await handleSaveGet(env, "user1", "demo:bounce");
+    assert.equal(res.status, 404);
+  });
+
+  it("returns 200 with the bucket field when present", async () => {
+    env.BUCKET.map.set(
+      "save/user1/demo:bounce",
+      JSON.stringify({ version: 1, bucket: { hi: 42 }, updated_at: 1700000000000 }),
+    );
+    const res = await handleSaveGet(env, "user1", "demo:bounce");
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { bucket: { hi: 42 } });
+  });
+
+  it("isolates by uid prefix", async () => {
+    env.BUCKET.map.set(
+      "save/user1/demo:bounce",
+      JSON.stringify({ version: 1, bucket: { hi: 42 }, updated_at: 1 }),
+    );
+    const res = await handleSaveGet(env, "user2", "demo:bounce");
+    assert.equal(res.status, 404);
+  });
+
+  it("returns 200 + empty bucket when the R2 record is corrupt JSON", async () => {
+    env.BUCKET.map.set("save/user1/demo:bounce", "{not json");
+    const res = await handleSaveGet(env, "user1", "demo:bounce");
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { bucket: {} });
+  });
+});
+
+describe("handleSavePut", () => {
+  let env;
+  beforeEach(() => { env = makeEnv(); });
+
+  it("writes a record with version + updated_at", async () => {
+    const req = jsonBodyRequest("PUT", { bucket: { hi: 42 } });
+    const res = await handleSavePut(env, "user1", "demo:bounce", req);
+    assert.equal(res.status, 204);
+    const stored = JSON.parse(env.BUCKET.map.get("save/user1/demo:bounce"));
+    assert.equal(stored.version, 1);
+    assert.deepEqual(stored.bucket, { hi: 42 });
+    assert.equal(typeof stored.updated_at, "number");
+  });
+
+  it("returns 413 when Content-Length exceeds 70000", async () => {
+    const req = new Request("https://x/save/test", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", "Content-Length": "70001" },
+      body: JSON.stringify({ bucket: {} }),
+    });
+    const res = await handleSavePut(env, "user1", "demo:bounce", req);
+    assert.equal(res.status, 413);
+  });
+
+  it("returns 400 when body is not JSON", async () => {
+    const req = new Request("https://x/save/test", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    });
+    const res = await handleSavePut(env, "user1", "demo:bounce", req);
+    assert.equal(res.status, 400);
+  });
+
+  it("returns 400 when body lacks a bucket field", async () => {
+    const req = jsonBodyRequest("PUT", { not_bucket: 1 });
+    const res = await handleSavePut(env, "user1", "demo:bounce", req);
+    assert.equal(res.status, 400);
+  });
+
+  it("returns 400 when bucket is not a plain object", async () => {
+    const req = jsonBodyRequest("PUT", { bucket: [1, 2] });
+    const res = await handleSavePut(env, "user1", "demo:bounce", req);
+    assert.equal(res.status, 400);
+  });
+});
+
+describe("handleSaveDelete", () => {
+  let env;
+  beforeEach(() => { env = makeEnv(); });
+
+  it("returns 204 even when the entry was missing (idempotent)", async () => {
+    const res = await handleSaveDelete(env, "user1", "demo:bounce");
+    assert.equal(res.status, 204);
+  });
+
+  it("removes an existing entry", async () => {
+    env.BUCKET.map.set("save/user1/demo:bounce", "stub");
+    const res = await handleSaveDelete(env, "user1", "demo:bounce");
+    assert.equal(res.status, 204);
+    assert.equal(env.BUCKET.map.has("save/user1/demo:bounce"), false);
+  });
+});

--- a/dev/js/editor-play.js
+++ b/dev/js/editor-play.js
@@ -113,6 +113,19 @@ export async function runGame() {
     if (f.name.endsWith(".lua")) moduleMap[f.name] = f.content;
   }
 
+  const user = state.auth && state.auth.currentUser;
+  const cartId = state.currentGameId || "scratch";
+  const saveHook = (user && state.currentGameId)
+    ? {
+        backend: new window.MonoSave.CloudBackend({
+          uid: user.uid,
+          getToken: () => user.getIdToken(),
+          apiUrl: "https://api.monogame.cc",
+        }),
+        cartId,
+      }
+    : undefined;
+
   Mono.boot("editor-screen", {
     source: mainFile.content,
     colors: 4,
@@ -120,10 +133,10 @@ export async function runGame() {
     readFile: async (name) => fileMap[name] || "",
     modules: moduleMap,
     assets: state.currentAssets,
-    cartId: state.currentGameId || "scratch",
+    cartId,
     saveBackend: state.currentGameId ? "persistent" : "memory",
+    save: saveHook,
   }).then(() => {
-    // Apply shader config after engine is ready
     applyShaderConfig();
   }).catch((e) => {
     showEngineError(e.message || String(e));

--- a/dev/js/editor-play.js
+++ b/dev/js/editor-play.js
@@ -115,16 +115,22 @@ export async function runGame() {
 
   const user = state.auth && state.auth.currentUser;
   const cartId = state.currentGameId || "scratch";
-  const saveHook = (user && state.currentGameId)
-    ? {
-        backend: new window.MonoSave.CloudBackend({
-          uid: user.uid,
-          getToken: () => user.getIdToken(),
-          apiUrl: "https://api.monogame.cc",
-        }),
-        cartId,
-      }
-    : undefined;
+  // Dispose the previous CloudBackend before constructing a new one —
+  // each instance attaches visibilitychange + beforeunload listeners
+  // that would otherwise accumulate across editor resets.
+  if (state.cloudBackend && typeof state.cloudBackend.dispose === "function") {
+    state.cloudBackend.dispose();
+    state.cloudBackend = null;
+  }
+  let saveHook;
+  if (user && state.currentGameId) {
+    state.cloudBackend = new window.MonoSave.CloudBackend({
+      uid: user.uid,
+      getToken: () => user.getIdToken(),
+      apiUrl: "https://api.monogame.cc",
+    });
+    saveHook = { backend: state.cloudBackend, cartId };
+  }
 
   Mono.boot("editor-screen", {
     source: mainFile.content,

--- a/dev/js/state.js
+++ b/dev/js/state.js
@@ -42,6 +42,7 @@ export const state = {
 
   // Engine
   lastEngineError: null,
+  cloudBackend: null,    // CloudBackend instance for the current Play session — disposed on next runGame()
 
   // Realtime listener cleanup
   unsubGames: null,

--- a/docs/superpowers/plans/2026-05-03-cloud-save.md
+++ b/docs/superpowers/plans/2026-05-03-cloud-save.md
@@ -1,0 +1,1739 @@
+# Cloud Save / `CloudBackend` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `CloudBackend` that syncs per-cart `data_*` save state to a Cloudflare Worker + R2 for logged-in players, while keeping anonymous + headless flows on existing local backends. Anonymous local data is never deleted; first login uploads it only when cloud is empty.
+
+**Architecture:** `runtime/save.js` adds a `keyPrefix` option to `WebBackend` and a new `CloudBackend` class that composes a prefixed WebBackend as its durable mirror. Three new authenticated cosmi worker routes (`GET/PUT/DELETE /save/:cartId`) persist buckets to R2 under `save/<uid>/<cartId>`. `runtime/engine.js` accepts a pre-built backend via `opts.save` so runners (`play.html`, `dev/js/editor-play.js`) can inject CloudBackend when Firebase reports a signed-in user; otherwise the existing default-build path stays.
+
+**Tech Stack:** Vanilla JS classic scripts (UMD), Cloudflare Workers + R2, Firebase Auth (Web SDK 11.7.1, ES modules), Node `node:test`.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-cloud-save-design.md`
+
+**Conventions assumed by this plan:**
+- All new code is in plain JS / no transpilation. `runtime/save.js` is UMD; cosmi files are ES modules with the existing `node --test` runner.
+- New `CloudBackend` accepts injected dependencies (`fetch`, `storage`, `now`, `setTimeout`, `clearTimeout`) via constructor opts so unit tests can drive the timeline.
+- Worker endpoints follow the existing helper pattern: a thin route handler in `index.js` that calls a focused helper (`handleSaveGet/Put/Delete`) with `(env, uid, cartId, request?)` arguments.
+- R2 record format: `{ "version": 1, "bucket": <object>, "updated_at": <unix_ms> }`. Wrapper is added/stripped at the worker boundary so the client only sees `{ bucket }`.
+
+---
+
+### Task 1: WebBackend `keyPrefix` option
+
+**Files:**
+- Modify: `runtime/save.js`
+- Modify: `runtime/save.test.mjs`
+
+`WebBackend` currently hardcodes `"mono:save:" + cartId` as its localStorage key. Adding an optional `keyPrefix` constructor option lets `CloudBackend` reuse the class for its per-uid mirror without forking it.
+
+- [ ] **Step 1: Write failing tests for the new option**
+
+Append to `runtime/save.test.mjs` (after the existing WebBackend describe blocks):
+
+```js
+describe("WebBackend — keyPrefix option", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+
+  it("defaults to 'mono:save:' when no keyPrefix is provided", () => {
+    const storage = makeFakeStorage();
+    const b = new MonoSave.WebBackend({ storage });
+    b.write("g", '{"v":1}');
+    assert.deepEqual(storage._entries(), [["mono:save:g", '{"v":1}']]);
+  });
+
+  it("uses a custom keyPrefix when supplied", () => {
+    const storage = makeFakeStorage();
+    const b = new MonoSave.WebBackend({ storage, keyPrefix: "mono:save:abc:" });
+    b.write("g", '{"v":1}');
+    assert.deepEqual(storage._entries(), [["mono:save:abc:g", '{"v":1}']]);
+  });
+
+  it("two backends with different prefixes do not collide", () => {
+    const storage = makeFakeStorage();
+    const a = new MonoSave.WebBackend({ storage, keyPrefix: "mono:save:" });
+    const u = new MonoSave.WebBackend({ storage, keyPrefix: "mono:save:user1:" });
+    a.write("hi", '{"a":1}');
+    u.write("hi", '{"a":2}');
+    assert.deepEqual(a.read("hi"), { a: 1 });
+    assert.deepEqual(u.read("hi"), { a: 2 });
+  });
+
+  it("clear respects the prefix", () => {
+    const storage = makeFakeStorage();
+    const a = new MonoSave.WebBackend({ storage, keyPrefix: "mono:save:" });
+    const u = new MonoSave.WebBackend({ storage, keyPrefix: "mono:save:user1:" });
+    a.write("hi", '{"a":1}');
+    u.write("hi", '{"a":2}');
+    u.clear("hi");
+    assert.deepEqual(a.read("hi"), { a: 1 });    // anon untouched
+    assert.deepEqual(u.read("hi"), {});          // user1 cleared
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: FAIL — the keyPrefix option isn't honored yet (write goes to `mono:save:g` regardless).
+
+- [ ] **Step 3: Implement the option**
+
+In `runtime/save.js`, find the `WebBackend` class. Modify the constructor and `_key` method:
+
+```js
+  class WebBackend {
+    constructor(opts) {
+      const o = opts || {};
+      this._bridge =
+        ("bridge" in o) ? o.bridge :
+        (typeof globalThis !== "undefined" && globalThis.MonoSaveNative) ? globalThis.MonoSaveNative :
+        null;
+      this._storage =
+        ("storage" in o) ? o.storage :
+        (typeof globalThis !== "undefined" && globalThis.localStorage) ? globalThis.localStorage :
+        null;
+      this._warn = o.warn || ((typeof console !== "undefined") ? (m => console.warn(m)) : (() => {}));
+      this._warnedFor = new Set();
+      // keyPrefix lets CloudBackend reuse this class as a per-uid mirror
+      // without colliding with anonymous saves under the default prefix.
+      this._keyPrefix = (typeof o.keyPrefix === "string") ? o.keyPrefix : "mono:save:";
+    }
+    _key(cartId) { return this._keyPrefix + cartId; }
+    // ... rest unchanged ...
+```
+
+(The `read`, `write`, `clear` methods already call `this._key(cartId)` and need no further change.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: PASS — 4 new + all prior tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runtime/save.js runtime/save.test.mjs
+git commit -m "feat(save): WebBackend gains optional keyPrefix"
+```
+
+---
+
+### Task 2: `validateCartId` helper
+
+**Files:**
+- Modify: `cosmi/src/lib/path.js`
+- Modify: `cosmi/test/path.test.mjs`
+
+The existing `validateGameId` enforces the bare-alphanumeric R2 gameId format. The cloud-save endpoints accept richer cartIds (`demo:bounce`, `pkg:com.foo.bar`, etc.) — separate validator with its own ruleset.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `cosmi/test/path.test.mjs`:
+
+```js
+import { validateAgentPath, validateGameId, validateCartId } from "../src/lib/path.js";
+// ↑ replace the existing import line (validateAgentPath, validateGameId) with this
+
+describe("validateCartId", () => {
+  it("accepts plain alphanumerics", () => {
+    assert.equal(validateCartId("game42"), null);
+  });
+
+  it("accepts colons and underscores and hyphens", () => {
+    assert.equal(validateCartId("demo:bounce"), null);
+    assert.equal(validateCartId("pkg:com.foo"), "must match /^[a-zA-Z0-9:_-]{1,80}$/"); // dot rejected
+    assert.equal(validateCartId("pkg:com_foo"), null);
+    assert.equal(validateCartId("hi-score_v2"), null);
+  });
+
+  it("accepts boundary length 80", () => {
+    assert.equal(validateCartId("a".repeat(80)), null);
+  });
+
+  it("rejects empty / null / non-string", () => {
+    assert.match(validateCartId(""), /required/);
+    assert.match(validateCartId(null), /required/);
+    assert.match(validateCartId(undefined), /required/);
+    assert.match(validateCartId(42), /required/);
+  });
+
+  it("rejects > 80 chars", () => {
+    assert.match(validateCartId("a".repeat(81)), /must match/);
+  });
+
+  it("rejects path traversal vectors", () => {
+    assert.match(validateCartId("../foo"), /must match/);
+    assert.match(validateCartId("foo/bar"), /must match/);
+    assert.match(validateCartId("foo\\bar"), /must match/);
+    assert.match(validateCartId(".."), /must match/);
+  });
+
+  it("rejects whitespace and control chars", () => {
+    assert.match(validateCartId("foo bar"), /must match/);
+    assert.match(validateCartId("foo\tbar"), /must match/);
+    assert.match(validateCartId("foo\0bar"), /must match/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test cosmi/test/path.test.mjs`
+Expected: FAIL — `validateCartId` is not exported.
+
+- [ ] **Step 3: Implement `validateCartId`**
+
+In `cosmi/src/lib/path.js`, append:
+
+```js
+// Reject malformed cartId values before they hit R2 as a save key. cartId
+// is a richer namespace than gameId — it carries scheme prefixes like
+// "demo:bounce" or "pkg:com.foo.bar" — but path-traversal characters
+// (slash, backslash, dot, NUL, whitespace) must be rejected. The colon
+// is allowed because the only place cartIds appear is *inside* a path
+// segment, never as a delimiter on the worker side.
+export function validateCartId(s) {
+  if (typeof s !== "string" || !s) return "cartId required";
+  if (!/^[a-zA-Z0-9:_-]{1,80}$/.test(s)) {
+    return "must match /^[a-zA-Z0-9:_-]{1,80}$/";
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test cosmi/test/path.test.mjs`
+Expected: PASS — 7 new + all prior tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cosmi/src/lib/path.js cosmi/test/path.test.mjs
+git commit -m "feat(cosmi): add validateCartId for cloud-save endpoints"
+```
+
+---
+
+### Task 3: Worker `/save/:cartId` endpoints
+
+**Files:**
+- Modify: `cosmi/src/index.js`
+- Create: `cosmi/test/save-endpoint.test.mjs`
+
+Three authenticated routes that read/write/delete a per-user-per-cart R2 record. Helper functions are extracted (matching the existing `getFile/putFile/deleteFile` style around index.js:508) so they can be unit-tested with a fake R2 BUCKET.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `cosmi/test/save-endpoint.test.mjs`:
+
+```js
+// Cloud-save worker route tests. Drives the helpers directly with a
+// fake R2 BUCKET so we don't need a wrangler runtime.
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { handleSaveGet, handleSavePut, handleSaveDelete } from "../src/save-handlers.js";
+
+function makeFakeR2() {
+  const map = new Map();
+  return {
+    map,
+    get: async (key) => {
+      const v = map.get(key);
+      if (v == null) return null;
+      return { text: async () => v };
+    },
+    put: async (key, body) => { map.set(key, body); },
+    delete: async (key) => { map.delete(key); },
+  };
+}
+function makeEnv() { return { BUCKET: makeFakeR2() }; }
+function jsonBodyRequest(method, body, headers = {}) {
+  return new Request("https://x/save/test", {
+    method,
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("handleSaveGet", () => {
+  let env;
+  beforeEach(() => { env = makeEnv(); });
+
+  it("returns 404 when the entry is missing", async () => {
+    const res = await handleSaveGet(env, "user1", "demo:bounce");
+    assert.equal(res.status, 404);
+  });
+
+  it("returns 200 with the bucket field when present", async () => {
+    env.BUCKET.map.set(
+      "save/user1/demo:bounce",
+      JSON.stringify({ version: 1, bucket: { hi: 42 }, updated_at: 1700000000000 }),
+    );
+    const res = await handleSaveGet(env, "user1", "demo:bounce");
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { bucket: { hi: 42 } });
+  });
+
+  it("isolates by uid prefix", async () => {
+    env.BUCKET.map.set(
+      "save/user1/demo:bounce",
+      JSON.stringify({ version: 1, bucket: { hi: 42 }, updated_at: 1 }),
+    );
+    const res = await handleSaveGet(env, "user2", "demo:bounce");
+    assert.equal(res.status, 404);
+  });
+
+  it("returns 200 + empty bucket when the R2 record is corrupt JSON", async () => {
+    env.BUCKET.map.set("save/user1/demo:bounce", "{not json");
+    const res = await handleSaveGet(env, "user1", "demo:bounce");
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { bucket: {} });
+  });
+});
+
+describe("handleSavePut", () => {
+  let env;
+  beforeEach(() => { env = makeEnv(); });
+
+  it("writes a record with version + updated_at", async () => {
+    const req = jsonBodyRequest("PUT", { bucket: { hi: 42 } });
+    const res = await handleSavePut(env, "user1", "demo:bounce", req);
+    assert.equal(res.status, 204);
+    const stored = JSON.parse(env.BUCKET.map.get("save/user1/demo:bounce"));
+    assert.equal(stored.version, 1);
+    assert.deepEqual(stored.bucket, { hi: 42 });
+    assert.equal(typeof stored.updated_at, "number");
+  });
+
+  it("returns 413 when Content-Length exceeds 70000", async () => {
+    const req = new Request("https://x/save/test", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", "Content-Length": "70001" },
+      body: JSON.stringify({ bucket: {} }),
+    });
+    const res = await handleSavePut(env, "user1", "demo:bounce", req);
+    assert.equal(res.status, 413);
+  });
+
+  it("returns 400 when body is not JSON", async () => {
+    const req = new Request("https://x/save/test", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    });
+    const res = await handleSavePut(env, "user1", "demo:bounce", req);
+    assert.equal(res.status, 400);
+  });
+
+  it("returns 400 when body lacks a bucket field", async () => {
+    const req = jsonBodyRequest("PUT", { not_bucket: 1 });
+    const res = await handleSavePut(env, "user1", "demo:bounce", req);
+    assert.equal(res.status, 400);
+  });
+
+  it("returns 400 when bucket is not a plain object", async () => {
+    const req = jsonBodyRequest("PUT", { bucket: [1, 2] });
+    const res = await handleSavePut(env, "user1", "demo:bounce", req);
+    assert.equal(res.status, 400);
+  });
+});
+
+describe("handleSaveDelete", () => {
+  let env;
+  beforeEach(() => { env = makeEnv(); });
+
+  it("returns 204 even when the entry was missing (idempotent)", async () => {
+    const res = await handleSaveDelete(env, "user1", "demo:bounce");
+    assert.equal(res.status, 204);
+  });
+
+  it("removes an existing entry", async () => {
+    env.BUCKET.map.set("save/user1/demo:bounce", "stub");
+    const res = await handleSaveDelete(env, "user1", "demo:bounce");
+    assert.equal(res.status, 204);
+    assert.equal(env.BUCKET.map.has("save/user1/demo:bounce"), false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test cosmi/test/save-endpoint.test.mjs`
+Expected: FAIL — `Cannot find module '../src/save-handlers.js'`.
+
+- [ ] **Step 3: Create the helper module**
+
+Create `cosmi/src/save-handlers.js`:
+
+```js
+// Cloud save handlers. Pure functions over (env, uid, cartId[, request]) →
+// Response. Extracted from index.js's route table so they can be tested
+// without booting a wrangler runtime. Each handler is the leaf called
+// after auth + cartId validation in the main fetch handler.
+//
+// R2 record shape: { version: 1, bucket: <object>, updated_at: <unix_ms> }
+// The wrapper is opaque to the client; GET strips it down to { bucket }.
+
+const R2_PREFIX = "save/";
+const MAX_BODY_BYTES = 70_000;   // ~64KB JSON + headroom; defense in depth
+
+function r2Key(uid, cartId) {
+  return R2_PREFIX + uid + "/" + cartId;
+}
+
+function json(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": "Authorization, Content-Type",
+    },
+  });
+}
+
+function noContent() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": "Authorization, Content-Type",
+    },
+  });
+}
+
+export async function handleSaveGet(env, uid, cartId) {
+  const obj = await env.BUCKET.get(r2Key(uid, cartId));
+  if (!obj) return json(404, { error: "Not found" });
+  const text = await obj.text();
+  let parsed;
+  try { parsed = JSON.parse(text); } catch { parsed = null; }
+  // If the stored record is corrupt or shape-wrong, treat as empty bucket
+  // rather than 500. The client's mirror is the source of truth here;
+  // a successful 200 lets the client overwrite on next save.
+  const bucket = (parsed && typeof parsed === "object" && parsed.bucket
+                  && typeof parsed.bucket === "object" && !Array.isArray(parsed.bucket))
+    ? parsed.bucket : {};
+  return json(200, { bucket });
+}
+
+export async function handleSavePut(env, uid, cartId, request) {
+  const lenHeader = request.headers.get("Content-Length");
+  const len = lenHeader ? parseInt(lenHeader, 10) : 0;
+  if (len > MAX_BODY_BYTES) return json(413, { error: "body too large" });
+  let body;
+  try { body = await request.json(); }
+  catch { return json(400, { error: "invalid JSON" }); }
+  if (!body || typeof body !== "object") return json(400, { error: "body must be an object" });
+  const bucket = body.bucket;
+  if (!bucket || typeof bucket !== "object" || Array.isArray(bucket)) {
+    return json(400, { error: "body.bucket must be a plain object" });
+  }
+  const record = { version: 1, bucket, updated_at: Date.now() };
+  await env.BUCKET.put(r2Key(uid, cartId), JSON.stringify(record));
+  return noContent();
+}
+
+export async function handleSaveDelete(env, uid, cartId) {
+  await env.BUCKET.delete(r2Key(uid, cartId));
+  return noContent();
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test cosmi/test/save-endpoint.test.mjs`
+Expected: PASS — all 12 cases.
+
+- [ ] **Step 5: Wire the routes into `cosmi/src/index.js`**
+
+Find the import block near the top of `cosmi/src/index.js` (around the existing `import { lintEnginePrimitiveOverwrite, lintDataKeys } from "./lib/lint.js";`). Add:
+
+```js
+import { handleSaveGet, handleSavePut, handleSaveDelete } from "./save-handlers.js";
+```
+
+(Keep its companion below the existing path import.) Update the path import line from:
+
+```js
+import { validateAgentPath, validateGameId } from "./lib/path.js";
+```
+
+to:
+
+```js
+import { validateAgentPath, validateGameId, validateCartId } from "./lib/path.js";
+```
+
+In the `default.fetch(request, env)` block, just after the `// ── Admin: lint rejection log` block (around line 110-111) and before the file-endpoint match, add the save route table:
+
+```js
+      // ── Save endpoints (cloud-save / data_*) ──
+      const saveMatch = url.pathname.match(/^\/save\/([^/]+)$/);
+      if (saveMatch) {
+        const cartId = decodeURIComponent(saveMatch[1]);
+        const badCart = validateCartId(cartId);
+        if (badCart) return json(400, { error: badCart });
+        if (request.method === "GET")    return await handleSaveGet(env, uid, cartId);
+        if (request.method === "PUT")    return await handleSavePut(env, uid, cartId, request);
+        if (request.method === "DELETE") return await handleSaveDelete(env, uid, cartId);
+        return json(405, { error: "Method not allowed" });
+      }
+```
+
+- [ ] **Step 6: Smoke-check the wiring**
+
+Run: `node -e "import('./cosmi/src/index.js').then(() => console.log('OK'))"`
+Expected: prints `OK`. (The index.js is ESM via `package.json` `"type":"module"`, so dynamic import is the right load mechanism.)
+
+Run: `node --test cosmi/test/`
+Expected: PASS — all cosmi tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cosmi/src/save-handlers.js cosmi/src/index.js cosmi/test/save-endpoint.test.mjs
+git commit -m "feat(cosmi): GET/PUT/DELETE /save/:cartId — per-uid R2 cloud save"
+```
+
+---
+
+### Task 4: `runtime/engine.js` accepts pre-built `opts.save`
+
+**Files:**
+- Modify: `runtime/engine.js`
+
+The current backend resolution in `Mono.boot` always builds a fresh `WebBackend` or `MemoryBackend` from `opts.saveBackend`. Runners that want to inject `CloudBackend` (or any pre-built backend) need a passthrough — same shape `dev/headless/mono-runner.js` already uses (`save: { backend, cartId }`).
+
+- [ ] **Step 1: Modify the backend resolution block**
+
+In `runtime/engine.js`, find the block starting with `// ── Save backend resolution ──` (around line 1087-1108). Replace it with:
+
+```js
+    // ── Save backend resolution ──
+    // Two paths:
+    //   1. Runner supplied a pre-built hook (`opts.save = { backend, cartId }`)
+    //      — we use it verbatim. This is how dev/headless/mono-runner.js
+    //      injects MemoryBackend, and how play.html / editor inject
+    //      CloudBackend when a Firebase user is signed in.
+    //   2. Runner only supplied opts.cartId / opts.saveBackend — engine
+    //      builds a default WebBackend (persistent) or MemoryBackend.
+    let saveHook;
+    if (opts.save && opts.save.backend && typeof opts.save.cartId === "string" && opts.save.cartId) {
+      saveHook = opts.save;
+    } else {
+      const SaveLib = (typeof globalThis !== "undefined" && globalThis.MonoSave)
+                   || (typeof window !== "undefined" && window.MonoSave);
+      if (!SaveLib) {
+        showError("MonoSave not loaded. Include <script src=\"/runtime/save.js\"> before engine.js.");
+        return;
+      }
+      const _cartId = opts.cartId || ("anon:" + Math.random().toString(36).slice(2, 10));
+      const _requested = opts.saveBackend || (opts.cartId ? "persistent" : "memory");
+      if (_requested === "persistent" && !opts.cartId) {
+        throw new Error("Mono.boot: saveBackend=\"persistent\" requires opts.cartId");
+      }
+      saveHook = {
+        backend: (_requested === "memory") ? new SaveLib.MemoryBackend() : new SaveLib.WebBackend(),
+        cartId: _cartId,
+      };
+    }
+```
+
+(The subsequent `await Bindings.bind(lua, { ..., save: saveHook });` call is unchanged.)
+
+- [ ] **Step 2: Smoke-check engine.js parses**
+
+Run: `node --check runtime/engine.js`
+Expected: no output (no syntax errors).
+
+- [ ] **Step 3: Verify existing tests still pass**
+
+Run: `node --test runtime/save.test.mjs cosmi/test/`
+Expected: PASS — no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add runtime/engine.js
+git commit -m "feat(engine): Mono.boot accepts pre-built opts.save passthrough"
+```
+
+---
+
+### Task 5: `CloudBackend` skeleton + happy-path read
+
+**Files:**
+- Modify: `runtime/save.js`
+- Modify: `runtime/save.test.mjs`
+
+Lay down the constructor + the 200-response read path. Subsequent tasks layer on the failure paths, migration, debounce, clear, and flush.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `runtime/save.test.mjs`:
+
+```js
+describe("CloudBackend — constructor + read happy path", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+  function fetchOk(body, init = {}) {
+    return Object.assign(
+      Promise.resolve(new Response(JSON.stringify(body), {
+        status: 200, headers: { "Content-Type": "application/json" }, ...init,
+      })),
+      { _calls: [] },
+    );
+  }
+
+  it("calls GET <apiUrl>/save/<cartId> with the bearer token", async () => {
+    const calls = [];
+    const fetchFn = async (url, init) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({ bucket: { hi: 7 } }), { status: 200 });
+    };
+    const storage = makeFakeStorage();
+    const b = new MonoSave.CloudBackend({
+      uid: "user1",
+      getToken: async () => "TOKEN",
+      apiUrl: "https://api.example.com",
+      fetch: fetchFn,
+      storage,
+    });
+    const out = await b.read("demo:bounce");
+    assert.deepEqual(out, { hi: 7 });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "https://api.example.com/save/demo%3Abounce");
+    assert.equal(calls[0].init.method, "GET");
+    assert.equal(calls[0].init.headers.Authorization, "Bearer TOKEN");
+  });
+
+  it("writes the returned bucket to the per-uid mirror", async () => {
+    const fetchFn = async () =>
+      new Response(JSON.stringify({ bucket: { hi: 7 } }), { status: 200 });
+    const storage = makeFakeStorage();
+    const b = new MonoSave.CloudBackend({
+      uid: "user1",
+      getToken: async () => "TOKEN",
+      apiUrl: "https://api.example.com",
+      fetch: fetchFn,
+      storage,
+    });
+    await b.read("demo:bounce");
+    const entries = storage._entries();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0][0], "mono:save:user1:demo:bounce");
+    assert.deepEqual(JSON.parse(entries[0][1]), { hi: 7 });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: FAIL — `MonoSave.CloudBackend is not a constructor`.
+
+- [ ] **Step 3: Implement the skeleton + happy-path read**
+
+In `runtime/save.js`, immediately after the `WebBackend` class (and before the closing `return { ... }`), add:
+
+```js
+  // ── CloudBackend — per-uid R2-backed save with a localStorage mirror.
+  // Composes a prefixed WebBackend as the durable mirror so any read in
+  // offline or post-throw conditions falls back to the last known bucket
+  // without a network round-trip. All transports (fetch, storage, timing)
+  // are injectable so unit tests drive the timeline deterministically.
+  class CloudBackend {
+    constructor(opts) {
+      const o = opts || {};
+      if (typeof o.uid !== "string" || !o.uid) throw new Error("CloudBackend: uid required");
+      if (typeof o.getToken !== "function")    throw new Error("CloudBackend: getToken required");
+      if (typeof o.apiUrl !== "string" || !o.apiUrl) throw new Error("CloudBackend: apiUrl required");
+      this._uid = o.uid;
+      this._getToken = o.getToken;
+      this._apiUrl = o.apiUrl.replace(/\/+$/, "");
+      this._fetch = o.fetch || ((typeof globalThis !== "undefined" && globalThis.fetch) ? globalThis.fetch.bind(globalThis) : null);
+      if (!this._fetch) throw new Error("CloudBackend: fetch unavailable");
+      this._storage = ("storage" in o) ? o.storage :
+        (typeof globalThis !== "undefined" && globalThis.localStorage) ? globalThis.localStorage : null;
+      this._warn = o.warn || ((typeof console !== "undefined") ? (m => console.warn(m)) : (() => {}));
+      // Mirror = WebBackend at "mono:save:<uid>:" prefix. Reuses parse +
+      // warn-once + JSON shape checks without re-implementing them.
+      this._mirror = new WebBackend({
+        storage: this._storage,
+        bridge: null,                                        // mirror is localStorage-only
+        keyPrefix: "mono:save:" + this._uid + ":",
+        warn: this._warn,
+      });
+    }
+    _url(cartId) { return this._apiUrl + "/save/" + encodeURIComponent(cartId); }
+    async _authHeaders() {
+      const token = await this._getToken();
+      return { "Authorization": "Bearer " + token };
+    }
+    async read(cartId) {
+      const headers = await this._authHeaders();
+      const res = await this._fetch(this._url(cartId), { method: "GET", headers });
+      if (res.status === 200) {
+        const body = await res.json();
+        const bucket = (body && typeof body.bucket === "object" && body.bucket && !Array.isArray(body.bucket))
+          ? body.bucket : {};
+        this._mirror.write(cartId, JSON.stringify(bucket));
+        return bucket;
+      }
+      // Other paths land in later tasks. For now, fall back to mirror.
+      return this._mirror.read(cartId);
+    }
+    write(cartId, json) { /* Task 8 */ }
+    clear(cartId)       { /* Task 9 */ }
+  }
+```
+
+Update the `return { ... }` block at the bottom of the IIFE to export `CloudBackend`:
+
+```js
+  return {
+    MemoryBackend,
+    WebBackend,
+    CloudBackend,
+    serializeBucket,
+    validateKey,
+    QUOTA_BYTES,
+    MAX_KEY_LEN,
+    MAX_DEPTH,
+  };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: PASS — 2 new + all prior tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runtime/save.js runtime/save.test.mjs
+git commit -m "feat(save): CloudBackend skeleton + 200 read path"
+```
+
+---
+
+### Task 6: `CloudBackend.read` — 404, 401, network-error fallbacks
+
+**Files:**
+- Modify: `runtime/save.js`
+- Modify: `runtime/save.test.mjs`
+
+Now flesh out the failure paths around `read`. Migration (404 + anonymous mirror has data) is the next task — this one covers 404+empty, network error, and 401.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `runtime/save.test.mjs`:
+
+```js
+describe("CloudBackend — read failure paths", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+
+  it("returns {} on 404 when no anonymous mirror exists", async () => {
+    const fetchFn = async () => new Response(null, { status: 404 });
+    const storage = makeFakeStorage();
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage,
+    });
+    assert.deepEqual(await b.read("demo:bounce"), {});
+  });
+
+  it("falls back to per-uid mirror on network error", async () => {
+    const storage = makeFakeStorage();
+    storage.setItem("mono:save:u1:demo:bounce", '{"hi":99}');
+    const fetchFn = async () => { throw new Error("offline"); };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage,
+    });
+    assert.deepEqual(await b.read("demo:bounce"), { hi: 99 });
+  });
+
+  it("returns {} and warns once on 401", async () => {
+    const fetchFn = async () => new Response(null, { status: 401 });
+    const storage = makeFakeStorage();
+    const warnings = [];
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, warn: (m) => warnings.push(m),
+    });
+    assert.deepEqual(await b.read("demo:bounce"), {});
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /401/);
+  });
+
+  it("after 401 the backend is auth-dead (writes/clears no-op)", async () => {
+    // We won't fully exercise write yet (Task 8) — just verify the flag.
+    const fetchFn = async () => new Response(null, { status: 401 });
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage: makeFakeStorage(), warn: () => {},
+    });
+    await b.read("demo:bounce");
+    assert.equal(b._authDead, true);   // internal flag, exposed for test introspection
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: FAIL — current `read` returns `{}` from mirror on 404/401 but doesn't track auth-dead.
+
+- [ ] **Step 3: Update `CloudBackend.read`**
+
+Replace the `read` method in `runtime/save.js` with:
+
+```js
+    async read(cartId) {
+      const headers = await this._authHeaders();
+      let res;
+      try {
+        res = await this._fetch(this._url(cartId), { method: "GET", headers });
+      } catch (e) {
+        // Network failure — fall back to mirror, leave push enabled
+        // so subsequent writes can recover when connectivity returns.
+        return this._mirror.read(cartId);
+      }
+      if (res.status === 200) {
+        const body = await res.json();
+        const bucket = (body && typeof body.bucket === "object" && body.bucket && !Array.isArray(body.bucket))
+          ? body.bucket : {};
+        this._mirror.write(cartId, JSON.stringify(bucket));
+        return bucket;
+      }
+      if (res.status === 401) {
+        this._authDead = true;
+        this._warn("CloudBackend: 401 from cloud — disabling push for this session");
+        return {};
+      }
+      if (res.status === 404) {
+        // Migration logic in Task 7. For now, no anon mirror means {}.
+        return {};
+      }
+      // 5xx or other — fall back to mirror.
+      return this._mirror.read(cartId);
+    }
+```
+
+Initialize `_authDead` to `false` in the constructor (right after `this._mirror = ...`):
+
+```js
+      this._authDead = false;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: PASS — 4 new + all prior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runtime/save.js runtime/save.test.mjs
+git commit -m "feat(save): CloudBackend handles 404 / 401 / network failure on read"
+```
+
+---
+
+### Task 7: `CloudBackend.read` — migration on 404 + anonymous mirror
+
+**Files:**
+- Modify: `runtime/save.js`
+- Modify: `runtime/save.test.mjs`
+
+When the cloud GET returns 404 *and* the anonymous bucket (`mono:save:<cartId>`) has data, the user is "first-login on this device with prior anonymous progress." Push that bucket to cloud, mirror it under the per-uid prefix, leave the anonymous key untouched. The push uses the same debounce pipeline as regular writes (introduced in Task 8) — for this task, schedule it via `setTimeout(_, 0)` and we'll reuse the wiring once writes exist.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `runtime/save.test.mjs`:
+
+```js
+describe("CloudBackend — migration on 404 + anonymous mirror", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+
+  it("returns the anonymous bucket on 404 and writes it to the per-uid mirror", async () => {
+    const storage = makeFakeStorage();
+    storage.setItem("mono:save:demo:bounce", '{"hi":42}');   // anon mirror
+    let putBody = null;
+    const fetchFn = async (url, init) => {
+      if (init.method === "GET") return new Response(null, { status: 404 });
+      if (init.method === "PUT") { putBody = init.body; return new Response(null, { status: 204 }); }
+      throw new Error("unexpected method");
+    };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage,
+      // Inject setTimeout that runs immediately so the migration push happens synchronously for the test.
+      setTimeout: (fn) => { fn(); return 0; },
+      clearTimeout: () => {},
+    });
+    const out = await b.read("demo:bounce");
+    assert.deepEqual(out, { hi: 42 });
+
+    // Per-uid mirror now has the migrated data.
+    assert.equal(storage.getItem("mono:save:u1:demo:bounce"), '{"hi":42}');
+
+    // Anonymous mirror is preserved.
+    assert.equal(storage.getItem("mono:save:demo:bounce"), '{"hi":42}');
+
+    // Migration push was sent.
+    assert.ok(putBody, "expected a PUT to be issued for migration");
+    assert.deepEqual(JSON.parse(putBody), { bucket: { hi: 42 } });
+  });
+
+  it("returns {} on 404 when anonymous mirror is corrupt", async () => {
+    const storage = makeFakeStorage();
+    storage.setItem("mono:save:demo:bounce", "{not json");
+    const fetchFn = async () => new Response(null, { status: 404 });
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, warn: () => {},
+      setTimeout: (fn) => { fn(); return 0; }, clearTimeout: () => {},
+    });
+    assert.deepEqual(await b.read("demo:bounce"), {});
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: FAIL — migration path not implemented; PUT is never called.
+
+- [ ] **Step 3: Implement migration**
+
+In `runtime/save.js`, accept `setTimeout` / `clearTimeout` overrides in the constructor (so tests can drive timing). Update the constructor — add to the bottom of the body:
+
+```js
+      this._setTimeout = o.setTimeout || ((typeof globalThis !== "undefined") ? globalThis.setTimeout.bind(globalThis) : null);
+      this._clearTimeout = o.clearTimeout || ((typeof globalThis !== "undefined") ? globalThis.clearTimeout.bind(globalThis) : null);
+      this._pending = new Map();   // cartId → JSON string awaiting push
+      this._timer = null;
+```
+
+Add a private push method (placed right above `read`):
+
+```js
+    _schedulePush(cartId, json, delayMs) {
+      this._pending.set(cartId, json);
+      if (this._timer && this._clearTimeout) this._clearTimeout(this._timer);
+      this._timer = this._setTimeout ? this._setTimeout(() => this._flush(), delayMs) : null;
+    }
+    async _flush() {
+      this._timer = null;
+      if (this._authDead) { this._pending.clear(); return; }
+      const headers = await this._authHeaders();
+      const entries = Array.from(this._pending.entries());
+      for (const [cartId, json] of entries) {
+        try {
+          const res = await this._fetch(this._url(cartId), {
+            method: "PUT",
+            headers: { ...headers, "Content-Type": "application/json" },
+            body: JSON.stringify({ bucket: JSON.parse(json) }),
+          });
+          if (res.ok) { this._pending.delete(cartId); continue; }
+          if (res.status === 401) {
+            this._authDead = true;
+            this._pending.clear();
+            this._warn("CloudBackend: 401 on push — disabling push for this session");
+            return;
+          }
+          if (res.status === 413) {
+            this._pending.delete(cartId);
+            this._warn("CloudBackend: 413 on push (cartId=" + cartId + ") — clientside cap should have prevented this");
+            continue;
+          }
+          // 5xx: leave in pending, retry next debounce.
+        } catch {
+          // Network error: leave in pending, retry next debounce.
+        }
+      }
+    }
+```
+
+Then update the 404 branch in `read`:
+
+```js
+      if (res.status === 404) {
+        // First login on this device with anonymous progress on the same
+        // cartId? Read the anonymous mirror (DIFFERENT prefix from our
+        // per-uid mirror), and if it has a usable bucket, write it through
+        // to our mirror and schedule an immediate migration push. Anonymous
+        // key is intentionally NOT removed.
+        const anonRaw = this._storage ? this._storage.getItem("mono:save:" + cartId) : null;
+        if (anonRaw) {
+          let anonBucket;
+          try {
+            const parsed = JSON.parse(anonRaw);
+            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) anonBucket = parsed;
+          } catch {}
+          if (anonBucket) {
+            this._mirror.write(cartId, anonRaw);
+            this._schedulePush(cartId, anonRaw, 0);
+            return anonBucket;
+          }
+        }
+        return {};
+      }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: PASS — 2 new + all prior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runtime/save.js runtime/save.test.mjs
+git commit -m "feat(save): CloudBackend migrates anonymous bucket on first login"
+```
+
+---
+
+### Task 8: `CloudBackend.write` — debounce pipeline
+
+**Files:**
+- Modify: `runtime/save.js`
+- Modify: `runtime/save.test.mjs`
+
+`write` writes to mirror immediately + schedules a debounced push. Multiple writes in <1s collapse into one PUT (via `_pending` map replacement, already wired in Task 7).
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `runtime/save.test.mjs`:
+
+```js
+describe("CloudBackend — write + debounce", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+  function makeFakeTimer() {
+    let pendingFn = null;
+    let pendingDelay = -1;
+    return {
+      setTimeout: (fn, ms) => { pendingFn = fn; pendingDelay = ms; return 1; },
+      clearTimeout: () => { pendingFn = null; pendingDelay = -1; },
+      run: async () => {
+        const fn = pendingFn;
+        pendingFn = null; pendingDelay = -1;
+        if (fn) await fn();
+      },
+      get pendingDelay() { return pendingDelay; },
+      get hasPending() { return pendingFn !== null; },
+    };
+  }
+
+  it("writes to mirror immediately and schedules a 1000ms push", async () => {
+    const storage = makeFakeStorage();
+    const timer = makeFakeTimer();
+    const fetchFn = async () => new Response(null, { status: 204 });
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, setTimeout: timer.setTimeout, clearTimeout: timer.clearTimeout,
+    });
+    b.write("demo:bounce", '{"hi":42}');
+    assert.equal(storage.getItem("mono:save:u1:demo:bounce"), '{"hi":42}');
+    assert.equal(timer.pendingDelay, 1000);
+  });
+
+  it("multiple writes within debounce collapse into one PUT", async () => {
+    const storage = makeFakeStorage();
+    const timer = makeFakeTimer();
+    const calls = [];
+    const fetchFn = async (url, init) => { calls.push(init); return new Response(null, { status: 204 }); };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, setTimeout: timer.setTimeout, clearTimeout: timer.clearTimeout,
+    });
+    b.write("demo:bounce", '{"hi":1}');
+    b.write("demo:bounce", '{"hi":2}');
+    b.write("demo:bounce", '{"hi":3}');
+    assert.ok(timer.hasPending);
+    await timer.run();
+    assert.equal(calls.length, 1);
+    assert.deepEqual(JSON.parse(calls[0].body), { bucket: { hi: 3 } });
+  });
+
+  it("network error on push leaves entry in pending for retry", async () => {
+    const storage = makeFakeStorage();
+    const timer = makeFakeTimer();
+    let attempts = 0;
+    const fetchFn = async () => { attempts++; throw new Error("offline"); };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, setTimeout: timer.setTimeout, clearTimeout: timer.clearTimeout,
+    });
+    b.write("demo:bounce", '{"hi":1}');
+    await timer.run();
+    assert.equal(attempts, 1);
+    assert.equal(b._pending.get("demo:bounce"), '{"hi":1}');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: FAIL — `write` is still a stub.
+
+- [ ] **Step 3: Implement `write`**
+
+Replace the `write(cartId, json)` stub with:
+
+```js
+    write(cartId, json) {
+      // Mirror is the authoritative local copy. A failed cloud push must
+      // not leave the mirror behind — so write to mirror first, push next.
+      this._mirror.write(cartId, json);
+      if (this._authDead) return;
+      this._schedulePush(cartId, json, 1000);
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: PASS — 3 new + all prior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runtime/save.js runtime/save.test.mjs
+git commit -m "feat(save): CloudBackend.write — debounced PUT with retry on failure"
+```
+
+---
+
+### Task 9: `CloudBackend.clear` — immediate DELETE + cancel pending
+
+**Files:**
+- Modify: `runtime/save.js`
+- Modify: `runtime/save.test.mjs`
+
+Clear is destructive intent — issue DELETE immediately (not debounced). Cancel any pending push for this cartId.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `runtime/save.test.mjs`:
+
+```js
+describe("CloudBackend — clear", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+  function makeFakeTimer() {
+    let pendingFn = null;
+    return {
+      setTimeout: (fn) => { pendingFn = fn; return 1; },
+      clearTimeout: () => { pendingFn = null; },
+      get hasPending() { return pendingFn !== null; },
+    };
+  }
+
+  it("issues DELETE immediately and clears the per-uid mirror", async () => {
+    const storage = makeFakeStorage();
+    storage.setItem("mono:save:u1:demo:bounce", '{"hi":1}');
+    const calls = [];
+    const fetchFn = async (url, init) => { calls.push({ url, method: init.method }); return new Response(null, { status: 204 }); };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, setTimeout: () => 0, clearTimeout: () => {},
+    });
+    await b.clear("demo:bounce");
+    assert.equal(storage.getItem("mono:save:u1:demo:bounce"), null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "DELETE");
+    assert.equal(calls[0].url, "https://x/save/demo%3Abounce");
+  });
+
+  it("cancels a pending push for the same cartId", async () => {
+    const storage = makeFakeStorage();
+    const timer = makeFakeTimer();
+    const fetchFn = async () => new Response(null, { status: 204 });
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, setTimeout: timer.setTimeout, clearTimeout: timer.clearTimeout,
+    });
+    b.write("demo:bounce", '{"hi":1}');
+    assert.ok(timer.hasPending);
+    await b.clear("demo:bounce");
+    // Pending push for this cartId must be gone.
+    assert.equal(b._pending.has("demo:bounce"), false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: FAIL — `clear` is a stub.
+
+- [ ] **Step 3: Implement `clear`**
+
+Replace the `clear(cartId)` stub with:
+
+```js
+    async clear(cartId) {
+      this._mirror.clear(cartId);
+      this._pending.delete(cartId);
+      if (this._authDead) return;
+      try {
+        const headers = await this._authHeaders();
+        await this._fetch(this._url(cartId), { method: "DELETE", headers });
+      } catch {
+        // Network failure — local cleared, cloud will be cleared on next
+        // successful clear or overwritten on next save. Acceptable: a
+        // clear that doesn't reach the server is rare and not catastrophic.
+      }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: PASS — 2 new + all prior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runtime/save.js runtime/save.test.mjs
+git commit -m "feat(save): CloudBackend.clear — immediate DELETE + cancel pending"
+```
+
+---
+
+### Task 10: `CloudBackend` keepalive flush on page leave
+
+**Files:**
+- Modify: `runtime/save.js`
+- Modify: `runtime/save.test.mjs`
+
+`visibilitychange` (state==='hidden') and `beforeunload` listeners flush pending pushes via `fetch(..., { keepalive: true })`. Browsers guarantee keepalive requests survive page teardown.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `runtime/save.test.mjs`:
+
+```js
+describe("CloudBackend — keepalive flush on page leave", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+    };
+  }
+  function makeEventTarget() {
+    const handlers = {};
+    return {
+      addEventListener: (ev, fn) => { (handlers[ev] = handlers[ev] || []).push(fn); },
+      removeEventListener: () => {},
+      dispatchEvent: (ev) => { (handlers[ev.type] || []).forEach(fn => fn(ev)); },
+    };
+  }
+
+  it("registers visibilitychange + beforeunload listeners on construction", () => {
+    const target = makeEventTarget();
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: async () => new Response(null, { status: 204 }),
+      storage: makeFakeStorage(), setTimeout: () => 0, clearTimeout: () => {},
+      eventTarget: target, visibilityState: () => "visible",
+    });
+    // Bookkeeping: handlers were attached. (We don't expose them, but
+    // dispatching now should not throw.)
+    target.dispatchEvent({ type: "visibilitychange" });
+    target.dispatchEvent({ type: "beforeunload" });
+  });
+
+  it("issues a keepalive PUT for each pending entry on visibilitychange to hidden", async () => {
+    const target = makeEventTarget();
+    const calls = [];
+    const fetchFn = async (url, init) => { calls.push(init); return new Response(null, { status: 204 }); };
+    let visState = "visible";
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage: makeFakeStorage(),
+      setTimeout: () => 0, clearTimeout: () => {},
+      eventTarget: target, visibilityState: () => visState,
+    });
+    b.write("a", '{"v":1}');
+    b.write("b", '{"v":2}');
+    visState = "hidden";
+    target.dispatchEvent({ type: "visibilitychange" });
+    // Allow microtasks to drain.
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].keepalive, true);
+    assert.equal(calls[1].keepalive, true);
+  });
+
+  it("issues a keepalive PUT on beforeunload regardless of visibility", async () => {
+    const target = makeEventTarget();
+    const calls = [];
+    const fetchFn = async (url, init) => { calls.push(init); return new Response(null, { status: 204 }); };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage: makeFakeStorage(),
+      setTimeout: () => 0, clearTimeout: () => {},
+      eventTarget: target, visibilityState: () => "visible",
+    });
+    b.write("a", '{"v":1}');
+    target.dispatchEvent({ type: "beforeunload" });
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].keepalive, true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: FAIL — listeners not attached.
+
+- [ ] **Step 3: Implement keepalive flush**
+
+In the CloudBackend constructor, before the `_pending` initialization, add `eventTarget` + `visibilityState` injection:
+
+```js
+      this._eventTarget = ("eventTarget" in o) ? o.eventTarget :
+        (typeof globalThis !== "undefined" && globalThis.addEventListener) ? globalThis : null;
+      this._visibilityState = o.visibilityState ||
+        ((typeof document !== "undefined") ? (() => document.visibilityState) : (() => "visible"));
+```
+
+After the `_pending` / `_timer` init, register listeners:
+
+```js
+      if (this._eventTarget && this._eventTarget.addEventListener) {
+        this._eventTarget.addEventListener("visibilitychange", () => {
+          if (this._visibilityState() === "hidden") this._flushKeepalive();
+        });
+        this._eventTarget.addEventListener("beforeunload", () => this._flushKeepalive());
+      }
+```
+
+Add the `_flushKeepalive` method (alongside `_flush`):
+
+```js
+    async _flushKeepalive() {
+      if (this._pending.size === 0 || this._authDead) return;
+      const headers = await this._authHeaders();
+      const entries = Array.from(this._pending.entries());
+      for (const [cartId, json] of entries) {
+        try {
+          await this._fetch(this._url(cartId), {
+            method: "PUT",
+            headers: { ...headers, "Content-Type": "application/json" },
+            body: JSON.stringify({ bucket: JSON.parse(json) }),
+            keepalive: true,
+          });
+          this._pending.delete(cartId);
+        } catch {
+          // Page is unloading — best-effort. Mirror is durable, retry on next boot.
+        }
+      }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test runtime/save.test.mjs`
+Expected: PASS — 3 new + all prior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runtime/save.js runtime/save.test.mjs
+git commit -m "feat(save): CloudBackend flushes pending pushes via fetch keepalive on page leave"
+```
+
+---
+
+### Task 11: `play.html` — Firebase auth + backend selection
+
+**Files:**
+- Modify: `play.html`
+
+`play.html` doesn't currently load Firebase. Add a small ESM module that initializes Firebase Auth, waits for the auth state to settle, then constructs `CloudBackend` (logged in) or relies on `Mono.boot`'s default `WebBackend` (anonymous). Boot is gated on auth-ready.
+
+- [ ] **Step 1: Add Firebase init + auth gating**
+
+In `play.html`, find the existing `<script>` block that defines `GAMES` (around line 108-122) and the boot logic that follows. Replace the entire boot block with an async ESM initializer that runs after Firebase auth settles. The change is contained to the inline `<script>` block at the bottom of the file.
+
+Replace:
+
+```html
+<script>
+  var GAMES = { /* ... existing entries ... */ };
+  var API_URL = "https://api.monogame.cc";
+  var params = new URLSearchParams(location.search);
+  var gameName = params.get("game");
+  var gameId = params.get("id");
+  var entry = gameName && GAMES[gameName];
+
+  if (gameId) {
+    /* ... existing boot logic ... */
+  } else if (!entry) {
+    /* ... existing error UI ... */
+  } else {
+    /* ... existing demo boot ... */
+  }
+</script>
+```
+
+with the following two scripts (a classic config script, then a module that gates on auth):
+
+```html
+<script>
+  var GAMES = {
+    bounce:      { path: "/demo/bounce/main.lua",      colors: 1 },
+    dodge:       { path: "/demo/dodge/main.lua",       colors: 4 },
+    pong:        { path: "/demo/pong/main.lua",        colors: 4 },
+    invaders:    { path: "/demo/invaders/main.lua",    colors: 1 },
+    bubble:      { path: "/demo/bubble/main.lua",      colors: 4 },
+    starfighter: { path: "/demo/starfighter/main.lua", colors: 4 },
+    paint:       { path: "/demo/paint/main.lua",       colors: 4 },
+    tiltmaze:    { path: "/demo/tiltmaze/main.lua",    colors: 4 },
+    synth:       { path: "/demo/synth/main.lua",       colors: 4 },
+    clock:       { path: "/demo/clock/main.lua",       colors: 4 },
+    "engine-test": { path: "/demo/engine-test/main.lua", colors: 4 },
+    motion:      { path: "/demo/motion/main.lua",      colors: 4 },
+    save:        { path: "/demo/save/main.lua",        colors: 4 }
+  };
+  var API_URL = "https://api.monogame.cc";
+</script>
+
+<script type="module">
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.1/firebase-app.js";
+  import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.7.1/firebase-auth.js";
+
+  const app = initializeApp({
+    apiKey: "AIzaSyAyTiJx_JkVdQoh8b5bDo-ttvp175vy8PM",
+    authDomain: "mono-5b951.firebaseapp.com",
+    projectId: "mono-5b951",
+    storageBucket: "mono-5b951.firebasestorage.app",
+    messagingSenderId: "850069827366",
+    appId: "1:850069827366:web:a196c04bbf4c93bd061be7"
+  });
+  const auth = getAuth(app);
+
+  // Wait for the first auth state callback so we know whether we have a
+  // signed-in user before booting Mono. Resolves to the user (or null).
+  const user = await new Promise((resolve) => {
+    const unsub = onAuthStateChanged(auth, (u) => { unsub(); resolve(u); });
+  });
+
+  // Build the save backend if we're logged in; otherwise leave it for
+  // Mono.boot to default to WebBackend (anonymous).
+  function makeSaveHook(cartId) {
+    if (!user) return undefined;
+    return {
+      backend: new Mono.MonoSave.CloudBackend({
+        uid: user.uid,
+        getToken: () => user.getIdToken(),
+        apiUrl: API_URL,
+      }),
+      cartId,
+    };
+  }
+
+  const params = new URLSearchParams(location.search);
+  const gameName = params.get("game");
+  const gameId = params.get("id");
+  const entry = gameName && GAMES[gameName];
+
+  if (gameId) {
+    try {
+      const res = await fetch(API_URL + "/games/" + gameId + "/published");
+      if (!res.ok) throw new Error("Game not found");
+      const data = await res.json();
+      document.title = "Mono \u2014 " + (data.title || "Game");
+      document.getElementById("back-btn").href = "/";
+
+      let mainSrc = "";
+      const modules = {};
+      const assets = {};
+      const textFiles = {};
+      const mimeByExt = { png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", gif: "image/gif", webp: "image/webp", bmp: "image/bmp" };
+      for (const f of data.files) {
+        if (f.encoding === "base64") {
+          const bin = Uint8Array.from(atob(f.content), (c) => c.charCodeAt(0));
+          const ext = f.name.split(".").pop().toLowerCase();
+          const mime = mimeByExt[ext] || "application/octet-stream";
+          assets[f.name] = URL.createObjectURL(new Blob([bin], { type: mime }));
+        } else if (f.name === "main.lua") {
+          mainSrc = f.content;
+        } else if (f.name.endsWith(".lua")) {
+          modules[f.name] = f.content;
+        } else {
+          textFiles[f.name] = f.content;
+        }
+      }
+      if (!mainSrc) throw new Error("No main.lua in published files");
+      try {
+        await Mono.boot("screen", {
+          source: mainSrc,
+          modules: modules,
+          assets: assets,
+          colors: 4,
+          readFile: (name) => modules[name] || textFiles[name] || null,
+          cartId: gameId,
+          save: makeSaveHook(gameId),
+        });
+      } finally {
+        for (const k in assets) URL.revokeObjectURL(assets[k]);
+      }
+      Mono.shader.preset();
+    } catch (e) {
+      console.error("Boot failed:", e);
+      document.getElementById("error").style.display = "block";
+      document.getElementById("error").textContent = "Failed to load game: " + e.message;
+      document.getElementById("console").style.display = "none";
+    }
+  } else if (!entry) {
+    document.getElementById("error").style.display = "block";
+    document.getElementById("error").textContent = gameName
+      ? 'Unknown game: "' + gameName + '". Available: ' + Object.keys(GAMES).join(", ")
+      : "No game specified. Use ?game=bounce or ?id=gameId";
+    document.getElementById("console").style.display = "none";
+  } else {
+    document.title = "Mono \u2014 " + gameName.charAt(0).toUpperCase() + gameName.slice(1);
+    const cartId = "demo:" + gameName;
+    Mono.boot("screen", {
+      game: entry.path,
+      colors: entry.colors,
+      cartId,
+      save: makeSaveHook(cartId),
+    }).then(() => {
+      Mono.shader.preset();
+    }).catch((e) => {
+      console.error("Boot failed:", e);
+      document.getElementById("error").style.display = "block";
+      document.getElementById("error").textContent = "Boot failed: " + e.message;
+    });
+  }
+</script>
+```
+
+Note: `Mono.MonoSave` doesn't exist as a property on `Mono` — `MonoSave` is a separate global set by `runtime/save.js`. Replace `Mono.MonoSave.CloudBackend` with `MonoSave.CloudBackend`. (Lift to a one-liner above the `if (gameId)` block to avoid duplication.)
+
+```js
+  const MonoSave = window.MonoSave;
+```
+
+- [ ] **Step 2: Smoke-test the static HTML**
+
+There's no JS test suite to drive a browser test. Open `play.html?game=save` in a browser:
+- Without signing in, the boot should work as before. localStorage entry `mono:save:demo:save` populates after a save.
+- (Sign-in flow needs end-to-end manual verification — see Task 13.)
+
+Run: `node --test runtime/save.test.mjs cosmi/test/`
+Expected: PASS — JS regressions still pass; no Lua/HTML test changes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add play.html
+git commit -m "feat(save): play.html selects CloudBackend when Firebase user signed in"
+```
+
+---
+
+### Task 12: `dev/js/editor-play.js` — auth-aware backend selection
+
+**Files:**
+- Modify: `dev/js/editor-play.js`
+
+The editor already has `state.auth` and runs only after auth fires (per `dev/js/app.js`). At boot time, `state.auth.currentUser` is the live Firebase user.
+
+- [ ] **Step 1: Update the boot call**
+
+In `dev/js/editor-play.js`, find the `Mono.boot("editor-screen", { ... })` call (around line 116). Replace it with the auth-aware version:
+
+```js
+  const user = state.auth && state.auth.currentUser;
+  const cartId = state.currentGameId || "scratch";
+  const saveHook = (user && state.currentGameId)
+    ? {
+        backend: new window.MonoSave.CloudBackend({
+          uid: user.uid,
+          getToken: () => user.getIdToken(),
+          apiUrl: "https://api.monogame.cc",
+        }),
+        cartId,
+      }
+    : undefined;
+
+  Mono.boot("editor-screen", {
+    source: mainFile.content,
+    colors: 4,
+    noAutoFit: true,
+    readFile: async (name) => fileMap[name] || "",
+    modules: moduleMap,
+    assets: state.currentAssets,
+    cartId,
+    saveBackend: state.currentGameId ? "persistent" : "memory",
+    save: saveHook,
+  }).then(() => {
+    applyShaderConfig();
+  }).catch((e) => {
+    showEngineError(e.message || String(e));
+    consolePrint("[error] " + (e.message || String(e)), "error");
+    stopGame();
+  });
+```
+
+The `save` field is consumed by `Mono.boot`'s passthrough (Task 4); `saveBackend` is left for the case where `save` is not supplied (logged-out scratch session — falls back to memory).
+
+- [ ] **Step 2: Smoke-test in the editor**
+
+This requires the dev server running. Manual: open `dev/index.html`, sign in, open a saved game, hit Play. Confirm no console errors mentioning `CloudBackend` or `MonoSave`. (Cloud round-trip verification is part of Task 13's manual end-to-end.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dev/js/editor-play.js
+git commit -m "feat(save): editor-play.js selects CloudBackend for logged-in users"
+```
+
+---
+
+### Task 13: Update local-save spec future-work pointer
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-02-local-save-design.md`
+
+The original spec's Future Work section now has a concrete shipped implementation. Update the bullet to point at this spec.
+
+- [ ] **Step 1: Edit the file**
+
+Replace the first bullet under `## Future Work` in `docs/superpowers/specs/2026-05-02-local-save-design.md`:
+
+From:
+
+```
+- **Cloud sync for published games on logged-in users.** Add a `CloudBackend` that mirrors locally for offline + speed and pushes debounced writes to a new Cosmi Worker endpoint (`GET/PUT/DELETE /save/<cartId>`) keyed by `<uid>:<cartId>` in R2. Last-write-wins for conflicts. The backend interface is already shaped to accommodate this — the runner's auth-detection branch picks `CloudBackend` when a Firebase user is signed in and the cart is a published R2 cart.
+```
+
+To:
+
+```
+- **Cloud sync for logged-in users.** Implemented in `docs/superpowers/specs/2026-05-03-cloud-save-design.md`. CloudBackend composes a per-uid WebBackend mirror, debounce-pushes to `GET/PUT/DELETE /save/:cartId` in cosmi, persists to R2 under `save/<uid>/<cartId>`. Cloud-wins on first login (anonymous local preserved, never deleted). All authenticated boots with a cartId go through CloudBackend.
+```
+
+- [ ] **Step 2: Run all tests one more time as a final regression sweep**
+
+Run: `node --test runtime/save.test.mjs cosmi/test/`
+Expected: PASS — every test in both suites.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-02-local-save-design.md
+git commit -m "docs(spec): point local-save future work at the cloud-save implementation"
+```
+
+---
+
+## Manual end-to-end verification
+
+After all 13 tasks land, run this verification (browser + production cosmi or `wrangler dev`):
+
+1. Open `play.html?game=save` while signed out.
+2. Save some fields in the demo. Confirm `localStorage["mono:save:demo:save"]` has the bucket.
+3. Sign in (via the editor / dashboard, then return to `play.html?game=save`).
+4. Reload. Confirm:
+   - The fields show the previously-saved values (came from the migration push → cloud → mirror round-trip).
+   - `localStorage["mono:save:<uid>:demo:save"]` has the bucket.
+   - `localStorage["mono:save:demo:save"]` is **still there** (anonymous preserved).
+   - In the cosmi worker logs (or R2 directly), `save/<uid>/demo:save` has a record with `version: 1` and `bucket: { ... }`.
+5. Sign out. Reload `play.html?game=save`. Confirm anonymous values reappear.
+6. Sign in on a second browser / incognito with the same account, open `play.html?game=save`. Confirm the cloud values appear (cloud → fresh mirror).
+
+If any step fails, check the browser console for `CloudBackend:` warnings and the cosmi worker logs (`wrangler tail`).
+
+## Self-review
+
+**Spec coverage:**
+
+- Lua API unchanged → no task needed.
+- Anonymous + headless flows preserved → Tasks 1, 4 (no behavior change paths).
+- WebBackend keyPrefix → Task 1.
+- CloudBackend class → Tasks 5, 6, 7, 8, 9, 10.
+- Worker endpoints → Task 3.
+- cartId validator → Task 2.
+- Engine.js opts.save passthrough → Task 4.
+- play.html backend selection → Task 11.
+- editor-play.js backend selection → Task 12.
+- Local-save spec future-work pointer → Task 13.
+- Migration policy → Task 7 (404 + anon → push, anon preserved).
+- Push timing (debounce + keepalive flush) → Tasks 8 + 10.
+- Auth detection at boot → Tasks 11 + 12.
+
+**Placeholder scan:** No `TBD`, `TODO`, "fill in later", "similar to". Each step has full code or full command.
+
+**Type consistency:**
+- `CloudBackend` constructor accepts `{ uid, getToken, apiUrl, fetch?, storage?, warn?, setTimeout?, clearTimeout?, eventTarget?, visibilityState? }` everywhere it's referenced.
+- `_pending` is `Map<cartId: string, json: string>`, consistent across `write`, `_schedulePush`, `_flush`, `_flushKeepalive`, `clear`.
+- `saveHook = { backend, cartId }` matches the existing engine-bindings.js contract.
+- Worker handlers signature: `(env, uid, cartId[, request])` consistent across `handleSaveGet/Put/Delete`.
+- R2 record `{ version: 1, bucket: <object>, updated_at: <unix_ms> }` matches the spec.

--- a/docs/superpowers/specs/2026-05-02-local-save-design.md
+++ b/docs/superpowers/specs/2026-05-02-local-save-design.md
@@ -220,6 +220,6 @@ Two test surfaces (matching existing patterns in this repo):
 
 ## Future Work
 
-- **Cloud sync for published games on logged-in users.** Add a `CloudBackend` that mirrors locally for offline + speed and pushes debounced writes to a new Cosmi Worker endpoint (`GET/PUT/DELETE /save/<cartId>`) keyed by `<uid>:<cartId>` in R2. Last-write-wins for conflicts. The backend interface is already shaped to accommodate this — the runner's auth-detection branch picks `CloudBackend` when a Firebase user is signed in and the cart is a published R2 cart.
+- **Cloud sync for logged-in users.** Implemented in `docs/superpowers/specs/2026-05-03-cloud-save-design.md`. CloudBackend composes a per-uid WebBackend mirror, debounce-pushes to `GET/PUT/DELETE /save/:cartId` in cosmi, persists to R2 under `save/<uid>/<cartId>`. Cloud-wins on first login (anonymous local preserved, never deleted). All authenticated boots with a cartId go through CloudBackend.
 - **Save inspector** in `dev/`: list keys, show JSON, manual edit/delete during development.
 - **Per-cart quota raise** if a real game hits the 64KB limit. The cap is intentionally low to start; raising it is a one-line change once warranted.

--- a/docs/superpowers/specs/2026-05-03-cloud-save-design.md
+++ b/docs/superpowers/specs/2026-05-03-cloud-save-design.md
@@ -1,0 +1,307 @@
+# Cloud Save / `CloudBackend` — Design
+
+**Date:** 2026-05-03
+**Status:** Approved (brainstorming)
+**Builds on:** `docs/superpowers/specs/2026-05-02-local-save-design.md` (local save / `data_*` API)
+
+## Problem
+
+The local save spec shipped six `data_*` Lua functions, three backends (Memory / Web / Android-bridge), and a 64KB-per-cart cap. Persistence is per-device only — a player who plays on phone, switches to laptop, sees an empty bucket. The original spec's Future Work entry pointed at this gap and sketched a `CloudBackend` for logged-in users; this spec turns that sketch into a buildable design.
+
+## Goals
+
+- Logged-in players see the same `data_*` state across devices for any cart they play.
+- Anonymous players keep working exactly as today (localStorage only, no server round-trip on boot).
+- Login while local data exists triggers a one-shot upload (cloud-empty case only); the user's offline anonymous session is not lost on the way to the cloud.
+- Lua API is unchanged. `data_save` stays synchronous from the game's point of view.
+- Network outages and tab closures don't lose committed writes — local mirror is durable, pushes are idempotent and retried.
+- The Cloud backend slots into the existing backend interface (`read` / `write` / `clear`) without refactoring the bindings layer.
+
+## Non-Goals
+
+- Real-time multi-device sync (websockets, pub-sub). Sync happens at boot only; subsequent saves push from one device to the cloud, but other open sessions don't see them until their next boot.
+- Conflict merging across devices. Two devices saving the same key concurrently end with last-write-wins at the cloud level.
+- Per-user data export / inspect UI. Out of scope; users can manage data via in-game `data_clear` for now.
+- Automatic backups, snapshots, history.
+- Server-side validation that mirrors every client-side rule. The client validates; the server only enforces a defensive size cap.
+- Login/logout swap mid-game. Auth state is read once at boot.
+
+## Decisions (recap from brainstorming)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Trigger | Any authenticated boot with a cartId → CloudBackend. Anonymous → existing WebBackend. |
+| 2 | Migration on first login | Cloud-wins. If cloud is empty, upload anonymous local. **Anonymous local is preserved**, not cleared. |
+| 3 | Push timing | Debounced (~1s idle) + flush on `visibilitychange` (hidden) and `beforeunload`. |
+| 4 | Auth detection | Boot-time only (no live re-binding). |
+| 5 | Implementation | CloudBackend composes a WebBackend (with a different `keyPrefix`) as its durable mirror. |
+
+## Architecture
+
+```
+                        Lua user code
+        data_save / data_load / data_delete / ...     (unchanged)
+                          │
+                          ▼
+              runtime/engine-bindings.js               (unchanged)
+                          │
+                          ▼  hooks.save.backend
+        ┌─────────────────┼─────────────────┐
+        ▼                 ▼                 ▼
+  MemoryBackend      WebBackend       CloudBackend  ◀── new
+  (headless)         (anon + offline   (logged-in carts)
+                      editor)               │ wraps
+                                            ▼
+                                       WebBackend
+                                       keyPrefix: "mono:save:<uid>:"
+                                            │
+                                            └── + push to cosmi worker
+                                                    │
+                                                    ▼
+                                              R2 ("mono-dev"):
+                                              save/<uid>/<cartId>
+```
+
+**Storage layout summary**
+
+| Tier | Where | Key |
+|---|---|---|
+| Authoritative (logged-in) | R2 bucket `mono-dev` | `save/<uid>/<cartId>` |
+| Durable cache (logged-in) | `localStorage` | `mono:save:<uid>:<cartId>` |
+| Authoritative (anonymous) | `localStorage` | `mono:save:<cartId>` |
+| Authoritative (Android packaged) | `SharedPreferences` "mono_save" | `cartId` (unchanged from local-save spec) |
+| Lua-visible cache | engine-bindings.js in-memory bucket | (no key — single object per boot) |
+
+The two `localStorage` namespaces (anonymous vs logged-in) never collide because the prefix differs — same device can hold both an anonymous bucket and a logged-in mirror for the same cartId without overwriting each other.
+
+## Boot Sequence (logged-in path)
+
+1. Runner (e.g., `play.html`) detects Firebase user is signed in. Constructs:
+   ```js
+   new MonoSave.CloudBackend({
+     uid: user.uid,
+     getToken: () => user.getIdToken(),  // refreshable
+     apiUrl: "https://api.monogame.cc",
+   })
+   ```
+2. Engine calls `backend.read(cartId)` synchronously from JS perspective. Inside CloudBackend:
+   - `GET ${apiUrl}/save/<cartId>` with the user's idToken.
+   - **200**: parse `{ bucket }`, write to mirror, return bucket.
+   - **404**: check anonymous mirror (`mono:save:<cartId>`). If present, write to logged-in mirror, schedule a push to cloud (migration), return that bucket. If anonymous mirror is also empty, return `{}`.
+   - **Network failure**: read from logged-in mirror as fallback. If mirror is empty, return `{}`.
+   - **401**: warn, return `{}` and disable push for this session (token rejected — re-login needed).
+3. Bindings install Lua globals as today.
+
+The boot is allowed to be async; `Mono.boot` already returns a promise, and the engine awaits the read.
+
+## Runtime Operations
+
+| Lua call | CloudBackend behavior |
+|---|---|
+| `data_save(k, v)` | Validate + serialize via existing `serializeBucket`, mirror.write immediately, mark `pending[cartId] = json`, schedule debounced push (1s idle). |
+| `data_delete(k)` | Same path — mirror.write + push. (No separate DELETE endpoint per key; full bucket replaces.) |
+| `data_load(k)` | Reads from in-memory cache (engine-bindings.js layer). Zero CloudBackend involvement after boot. |
+| `data_has(k)` / `data_keys()` | Same — cache only. |
+| `data_clear()` | mirror.clear immediately + `DELETE /save/<cartId>` (not debounced — destructive intent should land fast). Pending push for this cartId is cancelled. |
+
+## Debounce + Flush
+
+CloudBackend instance state:
+
+- `pending: Map<cartId, json>` — most recent serialized bucket awaiting push. Replaced (not appended) on each new write of the same cartId.
+- `timer: number | null` — single setTimeout handle.
+- Constants: `DEBOUNCE_MS = 1000`.
+
+```
+write(cartId, json):
+  mirror.write(cartId, json)               # synchronous, durable
+  pending.set(cartId, json)
+  clearTimeout(timer)
+  timer = setTimeout(flush, DEBOUNCE_MS)
+
+flush():
+  timer = null
+  for [cartId, json] of pending:
+    fetch PUT /save/<cartId> { body: { bucket: JSON.parse(json) } }
+      .ok                       → pending.delete(cartId)
+      .status === 401           → pending.clear(); console.warn; mark session "auth-dead"
+      .status === 413           → pending.delete(cartId); console.warn (clientside cap should have caught this)
+      .other or network error   → leave in pending; next debounce cycle retries
+```
+
+**Page-leave flush**: Constructor registers `visibilitychange` (state==='hidden') and `beforeunload` listeners. Each calls a `flushKeepalive` that issues `fetch(url, { method: 'PUT', body, headers, keepalive: true })` for each pending entry. The `keepalive` flag lets the request survive page teardown without needing the older `navigator.sendBeacon` API (which would force POST and require a separate worker route). Modern browser support: Chromium / Firefox / Safari 16+. Older Safari falls back to a best-effort synchronous fetch — acceptable, since the mirror is already durable and the push will retry on next boot.
+
+## Worker — `cosmi/src/index.js`
+
+Three new authenticated routes. All require `verifyAuth(request, env)` to return a non-null uid; otherwise 401.
+
+```
+GET    /save/:cartId       → 200 { bucket: <object> } | 404
+PUT    /save/:cartId       → 204 on success
+                              413 if Content-Length > 70_000 (defense in depth)
+                              400 on body parse failure
+DELETE /save/:cartId       → 204 (idempotent — 204 even if entry was missing)
+```
+
+**cartId validation**: new `validateCartId(s)` in `cosmi/src/lib/path.js`. Rules:
+- 1..80 characters
+- Charset `[a-zA-Z0-9:_-]` only (covers `demo:bounce`, `pkg:com.foo.bar`, plain R2 gameIds)
+- No path traversal (no `/`, no `..`, no leading `.`)
+
+400 with `{ error: "invalid cartId" }` on violation.
+
+**R2 layout**:
+```
+key:   save/<uid>/<cartId>
+value: { "version": 1, "bucket": {...}, "updated_at": <unix_ms> }
+```
+
+- `version` reserved for future schema changes (rename keys, add metadata).
+- `updated_at` set server-side at PUT; useful for debugging and future "last sync" UI.
+- Wrapper overhead is ~50 bytes; R2 entry can be up to ~65586 bytes.
+
+**Authorization**:
+- Each request's R2 access is scoped to `save/<uid>/...` derived from the verified token. A user cannot read or write another user's cart save even by guessing the path — the worker constructs the R2 key from `verifyAuth`'s uid, never from a body field.
+- CORS: existing `corsResponse` pattern. `Access-Control-Allow-Origin: *`, allow `Authorization` and `Content-Type` headers.
+
+## Migration: First Login
+
+Triggered when CloudBackend's boot read sees 404 from the cloud AND an anonymous mirror exists for the same cartId.
+
+```
+read(cartId):  // when GET returned 404
+  anon = window.localStorage.getItem("mono:save:" + cartId)
+  if anon:
+    parsed = safe-parse(anon)
+    if parsed is plain object:
+      // 1. Write to logged-in mirror
+      mirror.write(cartId, anon)             // pre-stringified, no re-parse cost
+      // 2. Schedule a push (uses the standard debounce pipeline)
+      pending.set(cartId, anon)
+      clearTimeout(timer); timer = setTimeout(flush, 0)   // immediate, not 1s
+      // 3. Return the bucket; anonymous key is NOT deleted
+      return parsed
+  return {}
+```
+
+The anonymous key remains in localStorage. If the user logs out later, their pre-login progress is still there. If they log back in (same uid), the cloud copy now matches what was migrated, so subsequent boots take the normal 200 path — the migration logic is dormant.
+
+**What if anonymous mirror is corrupt?** safe-parse returns `{}` on JSON failure. Migration falls through to the empty-bucket case. Existing WebBackend warn-once behavior for corrupt local data still applies if the user goes back to anonymous mode.
+
+## WebBackend Change (composition)
+
+`runtime/save.js` `WebBackend` gains a single optional constructor option: `keyPrefix`. Defaults to `"mono:save:"`. Only `_key(cartId)` reads the prefix:
+
+```js
+_key(cartId) { return this._keyPrefix + cartId; }
+```
+
+CloudBackend instantiates its mirror with `new WebBackend({ keyPrefix: "mono:save:" + uid + ":" })`. All other WebBackend logic (read/write/clear, JSON parse, warn-once) is reused without change.
+
+This is a contract-compatible additive change — existing `new WebBackend()` calls (anonymous flow) continue to use the default prefix.
+
+## Auth Detection
+
+Each runner injects the right backend at boot. New helper in `runtime/save.js` is **not** added — auth detection belongs in the runner because Firebase is a runner-level dependency, not an engine concern.
+
+```js
+// runner pseudo-code (play.html, dev/js/editor-play.js, etc.)
+const user = firebase.auth().currentUser;
+const backend = user
+  ? new MonoSave.CloudBackend({
+      uid: user.uid,
+      getToken: () => user.getIdToken(),
+      apiUrl: "https://api.monogame.cc",
+    })
+  : new MonoSave.WebBackend();
+Mono.boot("screen", { ..., cartId, save: { backend, cartId } });
+```
+
+For boots that complete before Firebase auth has resolved, runners must `await firebase.auth().authStateReady()` (or equivalent) before constructing the backend. `play.html` already initializes Firebase asynchronously; the boot-trigger callback already runs after auth is ready.
+
+## Quotas and Limits
+
+| Item | Limit | On violation |
+|---|---|---|
+| Bucket size (client) | 65536 bytes | `serializeBucket` throws `save: quota exceeded` (existing) |
+| Body size (server) | 70000 bytes (Content-Length) | 413 |
+| cartId | 1..80 chars, `[a-zA-Z0-9:_-]` | 400 |
+| Auth | Firebase token via `verifyAuth` | 401 |
+
+R2 has effectively no per-user limit at this scale. Ten thousand users × fifty carts × 64KB ≈ 32 GB; well within free tier.
+
+## Error Handling
+
+Client-side errors map to existing `data_*` error contract — no new Lua-visible messages. Cloud-specific failure modes:
+
+| Condition | CloudBackend reaction | Lua game sees |
+|---|---|---|
+| Boot GET network error | mirror fallback, push disabled until next boot | normal `data_load` returns from mirror |
+| Boot GET 401 | empty bucket, push disabled, console.warn | first-run state |
+| Boot GET 5xx | mirror fallback, push enabled (will retry) | mirror state |
+| Push 401 | clear pending, mark "auth-dead", warn | nothing — game continues |
+| Push 5xx / network | leave in pending, retry next debounce | nothing |
+| Push 413 | drop from pending, warn | nothing — local kept, just not persisted |
+
+The game itself never observes cloud failure. The mirror is always coherent with the bindings cache; the cloud may temporarily lag behind. This is the natural offline-first UX.
+
+## Testing
+
+**JS unit tests** — extend `runtime/save.test.mjs`:
+- WebBackend `keyPrefix` option respected.
+- Two WebBackend instances with different prefixes don't collide on the same cartId.
+- CloudBackend constructor calls GET with the spec'd URL + Authorization header.
+- 200 response → mirror written + bucket returned.
+- 404 + anonymous mirror present → migration: mirror updated, push scheduled, anonymous key untouched.
+- 404 + no anonymous mirror → empty bucket, no push.
+- Network error → mirror fallback path returns mirror's content.
+- 401 boot → empty bucket, push disabled, warn emitted once.
+- `write` debounce: multiple writes in <1s collapse into one PUT.
+- `clear` PUT-bypassed: DELETE issued immediately, pending push for that cartId cancelled.
+- `flushKeepalive` issues `fetch(..., { keepalive: true })` for each pending entry on `visibilitychange` (hidden) and `beforeunload`.
+
+Use a fake `fetch`, fake `localStorage`, and fake `setTimeout/clearTimeout` to drive the timeline deterministically. `node:test` already supports this style; existing WebBackend tests use injected fakes.
+
+**Worker tests** — new `cosmi/test/save-endpoint.test.mjs`:
+- Unauthenticated → 401 on all three methods.
+- Invalid cartId → 400.
+- GET missing → 404.
+- PUT then GET round-trips the bucket; `version` and `updated_at` present in the R2 record.
+- PUT with `Content-Length > 70000` → 413 (don't actually write 70KB; fake the header).
+- DELETE missing → 204.
+- DELETE then GET → 404.
+- Cross-uid isolation: write as user A, query as user B → 404 (R2 prefix isolation).
+
+**End-to-end (manual)**:
+1. Anonymous play of `play.html?game=save` (the existing demo). Save some fields. Confirm `mono:save:demo:save` in localStorage.
+2. Sign in. Reload `play.html?game=save`. Confirm:
+   - The fields show the previously-saved values.
+   - `mono:save:<uid>:demo:save` exists in localStorage (mirror).
+   - `mono:save:demo:save` is also still there (anonymous preserved).
+   - R2 has `save/<uid>/demo:save`.
+3. Sign out. Reload. Confirm anonymous values reappear (logged-in mirror is dormant; anonymous bucket re-reads).
+4. Sign in on a second browser/incognito with the same account. Confirm step-2 values are present (cloud → new mirror).
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `runtime/save.js` | Add `keyPrefix` option to WebBackend. New `CloudBackend` class. Export it. |
+| `runtime/save.test.mjs` | Tests above. |
+| `cosmi/src/index.js` | Three new routes (`GET/PUT/DELETE /save/:cartId`). |
+| `cosmi/src/lib/path.js` | New `validateCartId` helper. |
+| `cosmi/test/save-endpoint.test.mjs` (new) | Worker-side tests. |
+| `cosmi/test/path.test.mjs` | Add `validateCartId` cases. |
+| `play.html` | Auth detection + backend selection at boot. |
+| `dev/js/editor-play.js` | Same. |
+| `dev/headless/mono-runner.js` | Untouched (always Memory backend). |
+| `dev/test-worker.js` | Untouched (always Memory backend). |
+| `docs/superpowers/specs/2026-05-02-local-save-design.md` | Update Future Work section to reference this spec. |
+
+## Future Work
+
+- **Live multi-device sync** via Cloudflare Durable Objects + websockets. Out of scope until a real game needs it.
+- **Conflict UI** when local and cloud have non-trivial divergence. Currently masked by cloud-wins.
+- **Save inspector** in `dev/` (already noted in v1 spec).
+- **Per-user quota cap** (e.g. 100 carts × 64KB) once usage data exists.
+- **Sync timestamp UI** ("last synced 3 minutes ago") for transparency.

--- a/docs/superpowers/specs/2026-05-03-cloud-save-design.md
+++ b/docs/superpowers/specs/2026-05-03-cloud-save-design.md
@@ -145,8 +145,8 @@ DELETE /save/:cartId       → 204 (idempotent — 204 even if entry was missing
 
 **cartId validation**: new `validateCartId(s)` in `cosmi/src/lib/path.js`. Rules:
 - 1..80 characters
-- Charset `[a-zA-Z0-9:_-]` only (covers `demo:bounce`, `pkg:com.foo.bar`, plain R2 gameIds)
-- No path traversal (no `/`, no `..`, no leading `.`)
+- Charset `[a-zA-Z0-9:_-]` only (covers `demo:bounce`, `pkg:com_mono_game`, plain R2 gameIds — dots are intentionally rejected since cartIds end up in R2 keys)
+- No path traversal (no `/`, no `..`, no `.`)
 
 400 with `{ error: "invalid cartId" }` on violation.
 

--- a/docs/superpowers/specs/2026-05-03-cloud-save-design.md
+++ b/docs/superpowers/specs/2026-05-03-cloud-save-design.md
@@ -305,3 +305,5 @@ Use a fake `fetch`, fake `localStorage`, and fake `setTimeout/clearTimeout` to d
 - **Save inspector** in `dev/` (already noted in v1 spec).
 - **Per-user quota cap** (e.g. 100 carts × 64KB) once usage data exists.
 - **Sync timestamp UI** ("last synced 3 minutes ago") for transparency.
+- **Worker body-size streaming inspection.** `handleSavePut` currently buffers the full body via `request.text()` before measuring length — an authenticated client that streams up to CF's 100MB platform cap can burn isolate CPU/memory before the 70KB post-parse check fires. Stream via `request.body.getReader()` and abort once the cap is exceeded. Bounded by `verifyAuth`, so not a public DoS, but worth tightening once we have real auth-misuse signal.
+- **`getToken` deadline.** `_authHeaders()` and `_flushKeepalive()` await `getToken()` with no `Promise.race` against a timeout. If Firebase's token refresh hangs (iOS Safari background, IndexedDB lock), the keepalive PUT misses the unload window. Wrap in a 1-second deadline that falls back to skipping the push (mirror is durable; next boot recovers).

--- a/play.html
+++ b/play.html
@@ -121,76 +121,97 @@
     motion:      { path: "/demo/motion/main.lua",      colors: 4 },
     save:        { path: "/demo/save/main.lua",        colors: 4 }
   };
-
   var API_URL = "https://api.monogame.cc";
-  var params = new URLSearchParams(location.search);
-  var gameName = params.get("game");
-  var gameId = params.get("id");
-  var entry = gameName && GAMES[gameName];
+</script>
+
+<script type="module">
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.1/firebase-app.js";
+  import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.7.1/firebase-auth.js";
+
+  const app = initializeApp({
+    apiKey: "AIzaSyAyTiJx_JkVdQoh8b5bDo-ttvp175vy8PM",
+    authDomain: "mono-5b951.firebaseapp.com",
+    projectId: "mono-5b951",
+    storageBucket: "mono-5b951.firebasestorage.app",
+    messagingSenderId: "850069827366",
+    appId: "1:850069827366:web:a196c04bbf4c93bd061be7"
+  });
+  const auth = getAuth(app);
+
+  // Wait for the first auth state callback so we know whether we have a
+  // signed-in user before booting Mono. Resolves to the user (or null).
+  const user = await new Promise((resolve) => {
+    const unsub = onAuthStateChanged(auth, (u) => { unsub(); resolve(u); });
+  });
+
+  // Build the save backend if we're logged in; otherwise leave it for
+  // Mono.boot to default to WebBackend (anonymous).
+  const MonoSave = window.MonoSave;
+  function makeSaveHook(cartId) {
+    if (!user) return undefined;
+    return {
+      backend: new MonoSave.CloudBackend({
+        uid: user.uid,
+        getToken: () => user.getIdToken(),
+        apiUrl: API_URL,
+      }),
+      cartId,
+    };
+  }
+
+  const params = new URLSearchParams(location.search);
+  const gameName = params.get("game");
+  const gameId = params.get("id");
+  const entry = gameName && GAMES[gameName];
 
   if (gameId) {
-    // Published game: load files from R2
-    (async function() {
-      try {
-        var res = await fetch(API_URL + "/games/" + gameId + "/published");
-        if (!res.ok) throw new Error("Game not found");
-        var data = await res.json();
-        document.title = "Mono \u2014 " + (data.title || "Game");
-        document.getElementById("back-btn").href = "/";
+    try {
+      const res = await fetch(API_URL + "/games/" + gameId + "/published");
+      if (!res.ok) throw new Error("Game not found");
+      const data = await res.json();
+      document.title = "Mono \u2014 " + (data.title || "Game");
+      document.getElementById("back-btn").href = "/";
 
-        var mainSrc = "";
-        var modules = {};
-        var assets = {};   // { "images/bg1.png": blobURL } — for loadImage
-        var textFiles = {}; // non-.lua text (cart.json, shader.json) — for readFile
-        var mimeByExt = {
-          png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
-          gif: "image/gif", webp: "image/webp", bmp: "image/bmp",
-        };
-        for (let f of data.files) {
-          try {
-            if (f.encoding === "base64") {
-              // Binary asset — decode to Blob URL for engine's loadImage()
-              const bin = Uint8Array.from(atob(f.content), function(c) { return c.charCodeAt(0); });
-              const ext = f.name.split(".").pop().toLowerCase();
-              const mime = mimeByExt[ext] || "application/octet-stream";
-              assets[f.name] = URL.createObjectURL(new Blob([bin], { type: mime }));
-            } else if (f.name === "main.lua") {
-              mainSrc = f.content;
-            } else if (f.name.endsWith(".lua")) {
-              modules[f.name] = f.content;
-            } else {
-              textFiles[f.name] = f.content;
-            }
-          } catch (e) {
-            throw new Error(f.name + ": " + (e.message || e));
-          }
+      let mainSrc = "";
+      const modules = {};
+      const assets = {};
+      const textFiles = {};
+      const mimeByExt = { png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", gif: "image/gif", webp: "image/webp", bmp: "image/bmp" };
+      for (const f of data.files) {
+        if (f.encoding === "base64") {
+          const bin = Uint8Array.from(atob(f.content), (c) => c.charCodeAt(0));
+          const ext = f.name.split(".").pop().toLowerCase();
+          const mime = mimeByExt[ext] || "application/octet-stream";
+          assets[f.name] = URL.createObjectURL(new Blob([bin], { type: mime }));
+        } else if (f.name === "main.lua") {
+          mainSrc = f.content;
+        } else if (f.name.endsWith(".lua")) {
+          modules[f.name] = f.content;
+        } else {
+          textFiles[f.name] = f.content;
         }
-        if (!mainSrc) throw new Error("No main.lua in published files");
-        try {
-          await Mono.boot("screen", {
-            source: mainSrc,
-            modules: modules,
-            assets: assets,
-            colors: 4,
-            readFile: function(name) {
-              return modules[name] || textFiles[name] || null;
-            },
-            cartId: gameId,
-          });
-        } finally {
-          // Engine has already fetched each blob into a wasm-side image.
-          // Release the URLs so the Blob bytes can be GC'd — safe whether
-          // boot succeeded or threw.
-          for (const k in assets) URL.revokeObjectURL(assets[k]);
-        }
-        Mono.shader.preset();
-      } catch(e) {
-        console.error("Boot failed:", e);
-        document.getElementById("error").style.display = "block";
-        document.getElementById("error").textContent = "Failed to load game: " + e.message;
-        document.getElementById("console").style.display = "none";
       }
-    })();
+      if (!mainSrc) throw new Error("No main.lua in published files");
+      try {
+        await Mono.boot("screen", {
+          source: mainSrc,
+          modules: modules,
+          assets: assets,
+          colors: 4,
+          readFile: (name) => modules[name] || textFiles[name] || null,
+          cartId: gameId,
+          save: makeSaveHook(gameId),
+        });
+      } finally {
+        for (const k in assets) URL.revokeObjectURL(assets[k]);
+      }
+      Mono.shader.preset();
+    } catch (e) {
+      console.error("Boot failed:", e);
+      document.getElementById("error").style.display = "block";
+      document.getElementById("error").textContent = "Failed to load game: " + e.message;
+      document.getElementById("console").style.display = "none";
+    }
   } else if (!entry) {
     document.getElementById("error").style.display = "block";
     document.getElementById("error").textContent = gameName
@@ -199,13 +220,15 @@
     document.getElementById("console").style.display = "none";
   } else {
     document.title = "Mono \u2014 " + gameName.charAt(0).toUpperCase() + gameName.slice(1);
+    const cartId = "demo:" + gameName;
     Mono.boot("screen", {
       game: entry.path,
       colors: entry.colors,
-      cartId: "demo:" + gameName,
-    }).then(function() {
+      cartId,
+      save: makeSaveHook(cartId),
+    }).then(() => {
       Mono.shader.preset();
-    }).catch(function(e) {
+    }).catch((e) => {
       console.error("Boot failed:", e);
       document.getElementById("error").style.display = "block";
       document.getElementById("error").textContent = "Boot failed: " + e.message;

--- a/runtime/engine-bindings.js
+++ b/runtime/engine-bindings.js
@@ -194,7 +194,13 @@
       if (!backend) throw new Error("hooks.save.backend is required");
       if (typeof cartId !== "string" || !cartId) throw new Error("hooks.save.cartId must be a non-empty string");
 
-      let bucket = backend.read(cartId);
+      // backend.read may be sync (MemoryBackend, WebBackend) or async
+      // (CloudBackend — fetches the cloud bucket). bind() is already async
+      // and engine.js awaits it, so awaiting here is safe and required —
+      // without it, async backends return a Promise that defeats every
+      // subsequent `bucket[key]` lookup and silently wipes saved data on
+      // the first write.
+      let bucket = await backend.read(cartId);
       if (!bucket || typeof bucket !== "object" || Array.isArray(bucket)) bucket = {};
 
       lua.global.set("data_save", (key, value) => {

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -75,42 +75,6 @@ var Mono = (() => {
     return audioCtx;
   }
 
-  // One-shot audio unlock. Mobile WebViews and Mobile Safari keep
-  // AudioContext suspended until creation+resume happens inside a real
-  // user-gesture event, even when mediaPlaybackRequiresUserGesture=false.
-  // We attach capture-phase listeners on the document so the very first
-  // touch/mouse/key event primes the context — earlier than any in-game
-  // sfx call would. The listener removes itself once the context is
-  // running so it's free after the first interaction.
-  let _audioUnlocked = false;
-  function _unlockAudio() {
-    if (_audioUnlocked) return;
-    try {
-      ensureAudio();
-      // Some browsers report state === "running" only after resume() resolves.
-      if (audioCtx && audioCtx.state !== "running" && audioCtx.resume) {
-        audioCtx.resume().catch(() => {});
-      }
-      _audioUnlocked = true;
-    } catch (e) { /* ignore — retry on next gesture */ }
-  }
-  if (typeof document !== "undefined") {
-    const opts = { capture: true, passive: true };
-    const fn = () => {
-      _unlockAudio();
-      if (_audioUnlocked) {
-        document.removeEventListener("touchstart", fn, opts);
-        document.removeEventListener("mousedown",  fn, opts);
-        document.removeEventListener("keydown",     fn, opts);
-        document.removeEventListener("pointerdown", fn, opts);
-      }
-    };
-    document.addEventListener("touchstart", fn, opts);
-    document.addEventListener("mousedown",  fn, opts);
-    document.addEventListener("keydown",     fn, opts);
-    document.addEventListener("pointerdown", fn, opts);
-  }
-
   let _noiseBuf = null; // shared noise buffer (lazy init)
   function getNoiseBuf() {
     const ctx = audioCtx;

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -1085,27 +1085,33 @@ var Mono = (() => {
       return;
     }
     // ── Save backend resolution ──
-    // opts.saveBackend ∈ "persistent" | "memory"; default depends on
-    // whether cartId was supplied. Boot fails fast if save.js is missing
-    // (matches the MonoDraw / MonoBindings load checks above) so a page
-    // that forgot the script tag doesn't silently install throwing-stub
-    // data_* globals only to surface as a runtime error from inside the
-    // game.
-    const SaveLib = (typeof globalThis !== "undefined" && globalThis.MonoSave)
-                 || (typeof window !== "undefined" && window.MonoSave);
-    if (!SaveLib) {
-      showError("MonoSave not loaded. Include <script src=\"/runtime/save.js\"> before engine.js.");
-      return;
+    // Two paths:
+    //   1. Runner supplied a pre-built hook (`opts.save = { backend, cartId }`)
+    //      — we use it verbatim. This is how dev/headless/mono-runner.js
+    //      injects MemoryBackend, and how play.html / editor inject
+    //      CloudBackend when a Firebase user is signed in.
+    //   2. Runner only supplied opts.cartId / opts.saveBackend — engine
+    //      builds a default WebBackend (persistent) or MemoryBackend.
+    let saveHook;
+    if (opts.save && opts.save.backend && typeof opts.save.cartId === "string" && opts.save.cartId) {
+      saveHook = opts.save;
+    } else {
+      const SaveLib = (typeof globalThis !== "undefined" && globalThis.MonoSave)
+                   || (typeof window !== "undefined" && window.MonoSave);
+      if (!SaveLib) {
+        showError("MonoSave not loaded. Include <script src=\"/runtime/save.js\"> before engine.js.");
+        return;
+      }
+      const _cartId = opts.cartId || ("anon:" + Math.random().toString(36).slice(2, 10));
+      const _requested = opts.saveBackend || (opts.cartId ? "persistent" : "memory");
+      if (_requested === "persistent" && !opts.cartId) {
+        throw new Error("Mono.boot: saveBackend=\"persistent\" requires opts.cartId");
+      }
+      saveHook = {
+        backend: (_requested === "memory") ? new SaveLib.MemoryBackend() : new SaveLib.WebBackend(),
+        cartId: _cartId,
+      };
     }
-    const _cartId = opts.cartId || ("anon:" + Math.random().toString(36).slice(2, 10));
-    const _requested = opts.saveBackend || (opts.cartId ? "persistent" : "memory");
-    if (_requested === "persistent" && !opts.cartId) {
-      throw new Error("Mono.boot: saveBackend=\"persistent\" requires opts.cartId");
-    }
-    const saveHook = {
-      backend: (_requested === "memory") ? new SaveLib.MemoryBackend() : new SaveLib.WebBackend(),
-      cartId: _cartId,
-    };
     await Bindings.bind(lua, {
       input: {
         btn:        (k) => !!keys[k],

--- a/runtime/engine.js
+++ b/runtime/engine.js
@@ -75,6 +75,42 @@ var Mono = (() => {
     return audioCtx;
   }
 
+  // One-shot audio unlock. Mobile WebViews and Mobile Safari keep
+  // AudioContext suspended until creation+resume happens inside a real
+  // user-gesture event, even when mediaPlaybackRequiresUserGesture=false.
+  // We attach capture-phase listeners on the document so the very first
+  // touch/mouse/key event primes the context — earlier than any in-game
+  // sfx call would. The listener removes itself once the context is
+  // running so it's free after the first interaction.
+  let _audioUnlocked = false;
+  function _unlockAudio() {
+    if (_audioUnlocked) return;
+    try {
+      ensureAudio();
+      // Some browsers report state === "running" only after resume() resolves.
+      if (audioCtx && audioCtx.state !== "running" && audioCtx.resume) {
+        audioCtx.resume().catch(() => {});
+      }
+      _audioUnlocked = true;
+    } catch (e) { /* ignore — retry on next gesture */ }
+  }
+  if (typeof document !== "undefined") {
+    const opts = { capture: true, passive: true };
+    const fn = () => {
+      _unlockAudio();
+      if (_audioUnlocked) {
+        document.removeEventListener("touchstart", fn, opts);
+        document.removeEventListener("mousedown",  fn, opts);
+        document.removeEventListener("keydown",     fn, opts);
+        document.removeEventListener("pointerdown", fn, opts);
+      }
+    };
+    document.addEventListener("touchstart", fn, opts);
+    document.addEventListener("mousedown",  fn, opts);
+    document.addEventListener("keydown",     fn, opts);
+    document.addEventListener("pointerdown", fn, opts);
+  }
+
   let _noiseBuf = null; // shared noise buffer (lazy init)
   function getNoiseBuf() {
     const ctx = audioCtx;

--- a/runtime/save.js
+++ b/runtime/save.js
@@ -218,11 +218,50 @@
         warn: this._warn,
       });
       this._authDead = false;
+      this._setTimeout = o.setTimeout || ((typeof globalThis !== "undefined") ? globalThis.setTimeout.bind(globalThis) : null);
+      this._clearTimeout = o.clearTimeout || ((typeof globalThis !== "undefined") ? globalThis.clearTimeout.bind(globalThis) : null);
+      this._pending = new Map();   // cartId → JSON string awaiting push
+      this._timer = null;
     }
     _url(cartId) { return this._apiUrl + "/save/" + encodeURIComponent(cartId); }
     async _authHeaders() {
       const token = await this._getToken();
       return { "Authorization": "Bearer " + token };
+    }
+    _schedulePush(cartId, json, delayMs) {
+      this._pending.set(cartId, json);
+      if (this._timer && this._clearTimeout) this._clearTimeout(this._timer);
+      this._timer = this._setTimeout ? this._setTimeout(() => this._flush(), delayMs) : null;
+    }
+    async _flush() {
+      this._timer = null;
+      if (this._authDead) { this._pending.clear(); return; }
+      const headers = await this._authHeaders();
+      const entries = Array.from(this._pending.entries());
+      for (const [cartId, json] of entries) {
+        try {
+          const res = await this._fetch(this._url(cartId), {
+            method: "PUT",
+            headers: { ...headers, "Content-Type": "application/json" },
+            body: JSON.stringify({ bucket: JSON.parse(json) }),
+          });
+          if (res.ok) { this._pending.delete(cartId); continue; }
+          if (res.status === 401) {
+            this._authDead = true;
+            this._pending.clear();
+            this._warn("CloudBackend: 401 on push — disabling push for this session");
+            return;
+          }
+          if (res.status === 413) {
+            this._pending.delete(cartId);
+            this._warn("CloudBackend: 413 on push (cartId=" + cartId + ") — clientside cap should have prevented this");
+            continue;
+          }
+          // 5xx: leave in pending, retry next debounce.
+        } catch {
+          // Network error: leave in pending, retry next debounce.
+        }
+      }
     }
     async read(cartId) {
       const headers = await this._authHeaders();
@@ -247,7 +286,30 @@
         return {};
       }
       if (res.status === 404) {
-        // Migration logic in Task 7. For now, no anon mirror means {}.
+        // First login on this device with anonymous progress on the same
+        // cartId? Read the anonymous mirror (DIFFERENT prefix from our
+        // per-uid mirror), and if it has a usable bucket, write it through
+        // to our mirror and schedule an immediate migration push. Anonymous
+        // key is intentionally NOT removed.
+        const anonRaw = this._storage ? this._storage.getItem("mono:save:" + cartId) : null;
+        if (anonRaw) {
+          let anonBucket;
+          try {
+            const parsed = JSON.parse(anonRaw);
+            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) anonBucket = parsed;
+          } catch {}
+          if (anonBucket) {
+            this._mirror.write(cartId, anonRaw);
+            // Schedule + immediately drain. The schedule plants the entry
+            // in _pending so a real timer would also flush it; the await on
+            // _flush guarantees the PUT is actually issued inline (callers
+            // and tests observe it before read returns). If the scheduled
+            // timer fires later it sees _pending empty and no-ops.
+            this._schedulePush(cartId, anonRaw, 0);
+            await this._flush();
+            return anonBucket;
+          }
+        }
         return {};
       }
       // 5xx or other — fall back to mirror.

--- a/runtime/save.js
+++ b/runtime/save.js
@@ -149,8 +149,11 @@
         null;
       this._warn = o.warn || ((typeof console !== "undefined") ? (m => console.warn(m)) : (() => {}));
       this._warnedFor = new Set();   // cartIds we've already warned about
+      // keyPrefix lets CloudBackend reuse this class as a per-uid mirror
+      // without colliding with anonymous saves under the default prefix.
+      this._keyPrefix = (typeof o.keyPrefix === "string") ? o.keyPrefix : "mono:save:";
     }
-    _key(cartId) { return "mono:save:" + cartId; }
+    _key(cartId) { return this._keyPrefix + cartId; }
     read(cartId) {
       const raw = this._bridge ? this._bridge.read(cartId)
                 : this._storage ? this._storage.getItem(this._key(cartId))

--- a/runtime/save.js
+++ b/runtime/save.js
@@ -190,9 +190,60 @@
     }
   }
 
+  // ── CloudBackend — per-uid R2-backed save with a localStorage mirror.
+  // Composes a prefixed WebBackend as the durable mirror so any read in
+  // offline or post-throw conditions falls back to the last known bucket
+  // without a network round-trip. All transports (fetch, storage, timing)
+  // are injectable so unit tests drive the timeline deterministically.
+  class CloudBackend {
+    constructor(opts) {
+      const o = opts || {};
+      if (typeof o.uid !== "string" || !o.uid) throw new Error("CloudBackend: uid required");
+      if (typeof o.getToken !== "function")    throw new Error("CloudBackend: getToken required");
+      if (typeof o.apiUrl !== "string" || !o.apiUrl) throw new Error("CloudBackend: apiUrl required");
+      this._uid = o.uid;
+      this._getToken = o.getToken;
+      this._apiUrl = o.apiUrl.replace(/\/+$/, "");
+      this._fetch = o.fetch || ((typeof globalThis !== "undefined" && globalThis.fetch) ? globalThis.fetch.bind(globalThis) : null);
+      if (!this._fetch) throw new Error("CloudBackend: fetch unavailable");
+      this._storage = ("storage" in o) ? o.storage :
+        (typeof globalThis !== "undefined" && globalThis.localStorage) ? globalThis.localStorage : null;
+      this._warn = o.warn || ((typeof console !== "undefined") ? (m => console.warn(m)) : (() => {}));
+      // Mirror = WebBackend at "mono:save:<uid>:" prefix. Reuses parse +
+      // warn-once + JSON shape checks without re-implementing them.
+      this._mirror = new WebBackend({
+        storage: this._storage,
+        bridge: null,                                        // mirror is localStorage-only
+        keyPrefix: "mono:save:" + this._uid + ":",
+        warn: this._warn,
+      });
+    }
+    _url(cartId) { return this._apiUrl + "/save/" + encodeURIComponent(cartId); }
+    async _authHeaders() {
+      const token = await this._getToken();
+      return { "Authorization": "Bearer " + token };
+    }
+    async read(cartId) {
+      const headers = await this._authHeaders();
+      const res = await this._fetch(this._url(cartId), { method: "GET", headers });
+      if (res.status === 200) {
+        const body = await res.json();
+        const bucket = (body && typeof body.bucket === "object" && body.bucket && !Array.isArray(body.bucket))
+          ? body.bucket : {};
+        this._mirror.write(cartId, JSON.stringify(bucket));
+        return bucket;
+      }
+      // Other paths land in later tasks. For now, fall back to mirror.
+      return this._mirror.read(cartId);
+    }
+    write(cartId, json) { /* Task 8 */ }
+    clear(cartId)       { /* Task 9 */ }
+  }
+
   return {
     MemoryBackend,
     WebBackend,
+    CloudBackend,
     serializeBucket,
     validateKey,
     QUOTA_BYTES,

--- a/runtime/save.js
+++ b/runtime/save.js
@@ -339,6 +339,19 @@
       // session token), every read would be a guaranteed-failure round
       // trip. Skip the network and serve from the mirror.
       if (this._authDead) return this._mirror.read(cartId);
+      // Wrap the entire read in try/catch so any thrown async (getToken
+      // hang, IndexedDB lock, malformed JSON response, transient SDK bug)
+      // falls back to the mirror instead of crashing Mono.boot. The
+      // game's last-known-good state stays playable when the cloud is
+      // unreachable for any reason — that's the offline-first guarantee.
+      try {
+        return await this._readNetwork(cartId);
+      } catch (e) {
+        this._warn("CloudBackend: read failed (" + (e && e.message || e) + ") — serving from mirror");
+        return this._mirror.read(cartId);
+      }
+    }
+    async _readNetwork(cartId) {
       const headers = await this._authHeaders();
       let res;
       try {
@@ -352,6 +365,17 @@
         const body = await res.json();
         const bucket = (body && typeof body.bucket === "object" && body.bucket && !Array.isArray(body.bucket))
           ? body.bucket : {};
+        // Empty bucket on a cart that has anonymous data MUST trigger
+        // migration. Without this, a previously-corrupt R2 record (which
+        // the worker rewrites to {bucket:{}} for graceful UX) silently
+        // hides the user's anonymous progress on first login. Treat
+        // "200 empty" the same as "404" for the migration check —
+        // the cloud authoritatively has nothing for this cart, but the
+        // local anon mirror has data we can recover.
+        if (Object.keys(bucket).length === 0) {
+          const migrated = this._tryMigrateAnon(cartId);
+          if (migrated) return migrated;
+        }
         this._mirror.write(cartId, JSON.stringify(bucket));
         return bucket;
       }
@@ -361,31 +385,34 @@
         return {};
       }
       if (res.status === 404) {
-        // First login on this device with anonymous progress on the same
-        // cartId? Read the anonymous mirror (DIFFERENT prefix from our
-        // per-uid mirror), and if it has a usable bucket, write it through
-        // to our mirror and schedule an immediate migration push. Anonymous
-        // key is intentionally NOT removed. The push is scheduled (delay 0)
-        // — fire-and-forget. CT10's keepalive flush catches it on tab
-        // close; the next debounce cycle catches it if the user keeps
-        // playing. Tests observe it via `await b._flushed`.
-        const anonRaw = this._storage ? this._storage.getItem(DEFAULT_KEY_PREFIX + cartId) : null;
-        if (anonRaw) {
-          let anonBucket;
-          try {
-            const parsed = JSON.parse(anonRaw);
-            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) anonBucket = parsed;
-          } catch {}
-          if (anonBucket) {
-            this._mirror.write(cartId, anonRaw);
-            this._schedulePush(cartId, anonRaw, 0);
-            return anonBucket;
-          }
-        }
+        const migrated = this._tryMigrateAnon(cartId);
+        if (migrated) return migrated;
         return {};
       }
       // 5xx or other — fall back to mirror.
       return this._mirror.read(cartId);
+    }
+    // First login on this device with anonymous progress on the same
+    // cartId? Read the anonymous mirror (DIFFERENT prefix from the
+    // per-uid mirror), and if it has a usable bucket, write it through
+    // to our mirror and schedule an immediate migration push. Anonymous
+    // key is intentionally NOT removed. The push is scheduled (delay 0)
+    // — fire-and-forget. The keepalive flush catches it on tab close;
+    // the next debounce cycle catches it if the user keeps playing.
+    // Tests observe it via `await b._flushed`. Returns the migrated
+    // bucket on success, null when there's nothing to migrate.
+    _tryMigrateAnon(cartId) {
+      const anonRaw = this._storage ? this._storage.getItem(DEFAULT_KEY_PREFIX + cartId) : null;
+      if (!anonRaw) return null;
+      let anonBucket;
+      try {
+        const parsed = JSON.parse(anonRaw);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) anonBucket = parsed;
+      } catch {}
+      if (!anonBucket) return null;
+      this._mirror.write(cartId, anonRaw);
+      this._schedulePush(cartId, anonRaw, 0);
+      return anonBucket;
     }
     write(cartId, json) {
       // Mirror is the authoritative local copy. A failed cloud push must

--- a/runtime/save.js
+++ b/runtime/save.js
@@ -227,8 +227,18 @@
       this._authDead = false;
       this._setTimeout = o.setTimeout || ((typeof globalThis !== "undefined") ? globalThis.setTimeout.bind(globalThis) : null);
       this._clearTimeout = o.clearTimeout || ((typeof globalThis !== "undefined") ? globalThis.clearTimeout.bind(globalThis) : null);
+      this._eventTarget = ("eventTarget" in o) ? o.eventTarget :
+        (typeof globalThis !== "undefined" && globalThis.addEventListener) ? globalThis : null;
+      this._visibilityState = o.visibilityState ||
+        ((typeof document !== "undefined") ? (() => document.visibilityState) : (() => "visible"));
       this._pending = new Map();   // cartId → JSON string awaiting push
       this._timer = null;
+      if (this._eventTarget && this._eventTarget.addEventListener) {
+        this._eventTarget.addEventListener("visibilitychange", () => {
+          if (this._visibilityState() === "hidden") this._flushKeepalive();
+        });
+        this._eventTarget.addEventListener("beforeunload", () => this._flushKeepalive());
+      }
     }
     _url(cartId) { return this._apiUrl + "/save/" + encodeURIComponent(cartId); }
     async _authHeaders() {
@@ -284,6 +294,27 @@
         // succeed once the token provider recovers.
         this._warn("CloudBackend: push aborted — " + (e && e.message || e));
       }
+    }
+    async _flushKeepalive() {
+      if (this._pending.size === 0 || this._authDead) return;
+      const headers = await this._authHeaders();
+      const entries = Array.from(this._pending.entries());
+      // Fire all PUTs synchronously: the page may be unloading any
+      // moment, and keepalive requests must be issued before the
+      // event handler returns to survive teardown. await'ing them
+      // sequentially would let later entries race the unload.
+      const inflight = entries.map(([cartId, json]) => {
+        const p = this._fetch(this._url(cartId), {
+          method: "PUT",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ bucket: JSON.parse(json) }),
+          keepalive: true,
+        });
+        return p.then(() => { this._pending.delete(cartId); }, () => {
+          // Page is unloading — best-effort. Mirror is durable, retry on next boot.
+        });
+      });
+      await Promise.all(inflight);
     }
     async read(cartId) {
       const headers = await this._authHeaders();

--- a/runtime/save.js
+++ b/runtime/save.js
@@ -341,7 +341,19 @@
       if (this._authDead) return;
       this._schedulePush(cartId, json, 1000);
     }
-    clear(cartId)       { /* Task 9 */ }
+    async clear(cartId) {
+      this._mirror.clear(cartId);
+      this._pending.delete(cartId);
+      if (this._authDead) return;
+      try {
+        const headers = await this._authHeaders();
+        await this._fetch(this._url(cartId), { method: "DELETE", headers });
+      } catch {
+        // Network failure — local cleared, cloud will be cleared on next
+        // successful clear or overwritten on next save. Acceptable: a
+        // clear that doesn't reach the server is rare and not catastrophic.
+      }
+    }
   }
 
   return {

--- a/runtime/save.js
+++ b/runtime/save.js
@@ -233,12 +233,30 @@
         ((typeof document !== "undefined") ? (() => document.visibilityState) : (() => "visible"));
       this._pending = new Map();   // cartId → JSON string awaiting push
       this._timer = null;
+      // Bind listener fns so dispose() can remove the exact same references.
+      // Without this, every CloudBackend constructed in a long-lived page
+      // (editor reset, hot reload) leaks one pair of listeners that fire
+      // a redundant keepalive PUT on every tab blur for the rest of the
+      // session.
+      this._onVisibility = () => {
+        if (this._visibilityState() === "hidden") this._flushKeepalive();
+      };
+      this._onBeforeUnload = () => this._flushKeepalive();
       if (this._eventTarget && this._eventTarget.addEventListener) {
-        this._eventTarget.addEventListener("visibilitychange", () => {
-          if (this._visibilityState() === "hidden") this._flushKeepalive();
-        });
-        this._eventTarget.addEventListener("beforeunload", () => this._flushKeepalive());
+        this._eventTarget.addEventListener("visibilitychange", this._onVisibility);
+        this._eventTarget.addEventListener("beforeunload",   this._onBeforeUnload);
       }
+    }
+    // Detach the page-leave listeners so this backend can be garbage-collected
+    // without leaking handlers across editor resets / hot reloads.
+    dispose() {
+      if (this._eventTarget && this._eventTarget.removeEventListener) {
+        this._eventTarget.removeEventListener("visibilitychange", this._onVisibility);
+        this._eventTarget.removeEventListener("beforeunload",   this._onBeforeUnload);
+      }
+      if (this._timer && this._clearTimeout) this._clearTimeout(this._timer);
+      this._timer = null;
+      this._pending.clear();
     }
     _url(cartId) { return this._apiUrl + "/save/" + encodeURIComponent(cartId); }
     async _authHeaders() {
@@ -317,6 +335,10 @@
       await Promise.all(inflight);
     }
     async read(cartId) {
+      // Once the session is auth-dead (a 401 has poisoned getToken or the
+      // session token), every read would be a guaranteed-failure round
+      // trip. Skip the network and serve from the mirror.
+      if (this._authDead) return this._mirror.read(cartId);
       const headers = await this._authHeaders();
       let res;
       try {

--- a/runtime/save.js
+++ b/runtime/save.js
@@ -26,6 +26,13 @@
   const QUOTA_BYTES = 65536;
   const MAX_KEY_LEN = 64;
   const MAX_DEPTH = 16;
+  // Default localStorage namespace. Anonymous saves land at
+  // DEFAULT_KEY_PREFIX + cartId. CloudBackend's per-uid mirror appends
+  // the uid before passing the prefix to its inner WebBackend, but it
+  // also reads anonymous saves directly from this namespace during
+  // first-login migration — keeping a single source of truth here
+  // prevents the two sites from drifting.
+  const DEFAULT_KEY_PREFIX = "mono:save:";
 
   // ── MemoryBackend — in-process Map keyed by cartId. Stores the
   // serialized JSON string so every read returns a fresh parse; callers
@@ -151,7 +158,7 @@
       this._warnedFor = new Set();   // cartIds we've already warned about
       // keyPrefix lets CloudBackend reuse this class as a per-uid mirror
       // without colliding with anonymous saves under the default prefix.
-      this._keyPrefix = (typeof o.keyPrefix === "string") ? o.keyPrefix : "mono:save:";
+      this._keyPrefix = (typeof o.keyPrefix === "string") ? o.keyPrefix : DEFAULT_KEY_PREFIX;
     }
     _key(cartId) { return this._keyPrefix + cartId; }
     read(cartId) {
@@ -214,7 +221,7 @@
       this._mirror = new WebBackend({
         storage: this._storage,
         bridge: null,                                        // mirror is localStorage-only
-        keyPrefix: "mono:save:" + this._uid + ":",
+        keyPrefix: DEFAULT_KEY_PREFIX + this._uid + ":",
         warn: this._warn,
       });
       this._authDead = false;
@@ -231,36 +238,51 @@
     _schedulePush(cartId, json, delayMs) {
       this._pending.set(cartId, json);
       if (this._timer && this._clearTimeout) this._clearTimeout(this._timer);
-      this._timer = this._setTimeout ? this._setTimeout(() => this._flush(), delayMs) : null;
+      // Track the in-flight flush as a Promise on the instance so callers
+      // and tests can `await b._flushed` to drain pending work without
+      // racing on microtasks. The setTimeout-driven invocation can't be
+      // awaited externally since the timer discards its return; the
+      // Promise we attach here closes that observability gap.
+      this._timer = this._setTimeout
+        ? this._setTimeout(() => { this._flushed = this._flush(); }, delayMs)
+        : null;
     }
     async _flush() {
       this._timer = null;
       if (this._authDead) { this._pending.clear(); return; }
-      const headers = await this._authHeaders();
-      const entries = Array.from(this._pending.entries());
-      for (const [cartId, json] of entries) {
-        try {
-          const res = await this._fetch(this._url(cartId), {
-            method: "PUT",
-            headers: { ...headers, "Content-Type": "application/json" },
-            body: JSON.stringify({ bucket: JSON.parse(json) }),
-          });
-          if (res.ok) { this._pending.delete(cartId); continue; }
-          if (res.status === 401) {
-            this._authDead = true;
-            this._pending.clear();
-            this._warn("CloudBackend: 401 on push — disabling push for this session");
-            return;
+      try {
+        const headers = await this._authHeaders();
+        const entries = Array.from(this._pending.entries());
+        for (const [cartId, json] of entries) {
+          try {
+            const res = await this._fetch(this._url(cartId), {
+              method: "PUT",
+              headers: { ...headers, "Content-Type": "application/json" },
+              body: JSON.stringify({ bucket: JSON.parse(json) }),
+            });
+            if (res.ok) { this._pending.delete(cartId); continue; }
+            if (res.status === 401) {
+              this._authDead = true;
+              this._pending.clear();
+              this._warn("CloudBackend: 401 on push — disabling push for this session");
+              return;
+            }
+            if (res.status === 413) {
+              this._pending.delete(cartId);
+              this._warn("CloudBackend: 413 on push (cartId=" + cartId + ") — clientside cap should have prevented this");
+              continue;
+            }
+            // 5xx: leave in pending, retry next debounce.
+          } catch {
+            // Network error: leave in pending, retry next debounce.
           }
-          if (res.status === 413) {
-            this._pending.delete(cartId);
-            this._warn("CloudBackend: 413 on push (cartId=" + cartId + ") — clientside cap should have prevented this");
-            continue;
-          }
-          // 5xx: leave in pending, retry next debounce.
-        } catch {
-          // Network error: leave in pending, retry next debounce.
         }
+      } catch (e) {
+        // getToken (or anything else outside the per-entry try) threw.
+        // Surfacing as warn so we don't leak unhandled rejections through
+        // the timer-driven invocation. Pending stays — next attempt may
+        // succeed once the token provider recovers.
+        this._warn("CloudBackend: push aborted — " + (e && e.message || e));
       }
     }
     async read(cartId) {
@@ -290,8 +312,11 @@
         // cartId? Read the anonymous mirror (DIFFERENT prefix from our
         // per-uid mirror), and if it has a usable bucket, write it through
         // to our mirror and schedule an immediate migration push. Anonymous
-        // key is intentionally NOT removed.
-        const anonRaw = this._storage ? this._storage.getItem("mono:save:" + cartId) : null;
+        // key is intentionally NOT removed. The push is scheduled (delay 0)
+        // — fire-and-forget. CT10's keepalive flush catches it on tab
+        // close; the next debounce cycle catches it if the user keeps
+        // playing. Tests observe it via `await b._flushed`.
+        const anonRaw = this._storage ? this._storage.getItem(DEFAULT_KEY_PREFIX + cartId) : null;
         if (anonRaw) {
           let anonBucket;
           try {
@@ -300,13 +325,7 @@
           } catch {}
           if (anonBucket) {
             this._mirror.write(cartId, anonRaw);
-            // Schedule + immediately drain. The schedule plants the entry
-            // in _pending so a real timer would also flush it; the await on
-            // _flush guarantees the PUT is actually issued inline (callers
-            // and tests observe it before read returns). If the scheduled
-            // timer fires later it sees _pending empty and no-ops.
             this._schedulePush(cartId, anonRaw, 0);
-            await this._flush();
             return anonBucket;
           }
         }

--- a/runtime/save.js
+++ b/runtime/save.js
@@ -334,7 +334,13 @@
       // 5xx or other — fall back to mirror.
       return this._mirror.read(cartId);
     }
-    write(cartId, json) { /* Task 8 */ }
+    write(cartId, json) {
+      // Mirror is the authoritative local copy. A failed cloud push must
+      // not leave the mirror behind — so write to mirror first, push next.
+      this._mirror.write(cartId, json);
+      if (this._authDead) return;
+      this._schedulePush(cartId, json, 1000);
+    }
     clear(cartId)       { /* Task 9 */ }
   }
 

--- a/runtime/save.js
+++ b/runtime/save.js
@@ -217,6 +217,7 @@
         keyPrefix: "mono:save:" + this._uid + ":",
         warn: this._warn,
       });
+      this._authDead = false;
     }
     _url(cartId) { return this._apiUrl + "/save/" + encodeURIComponent(cartId); }
     async _authHeaders() {
@@ -225,7 +226,14 @@
     }
     async read(cartId) {
       const headers = await this._authHeaders();
-      const res = await this._fetch(this._url(cartId), { method: "GET", headers });
+      let res;
+      try {
+        res = await this._fetch(this._url(cartId), { method: "GET", headers });
+      } catch (e) {
+        // Network failure — fall back to mirror, leave push enabled
+        // so subsequent writes can recover when connectivity returns.
+        return this._mirror.read(cartId);
+      }
       if (res.status === 200) {
         const body = await res.json();
         const bucket = (body && typeof body.bucket === "object" && body.bucket && !Array.isArray(body.bucket))
@@ -233,7 +241,16 @@
         this._mirror.write(cartId, JSON.stringify(bucket));
         return bucket;
       }
-      // Other paths land in later tasks. For now, fall back to mirror.
+      if (res.status === 401) {
+        this._authDead = true;
+        this._warn("CloudBackend: 401 from cloud — disabling push for this session");
+        return {};
+      }
+      if (res.status === 404) {
+        // Migration logic in Task 7. For now, no anon mirror means {}.
+        return {};
+      }
+      // 5xx or other — fall back to mirror.
       return this._mirror.read(cartId);
     }
     write(cartId, json) { /* Task 8 */ }

--- a/runtime/save.test.mjs
+++ b/runtime/save.test.mjs
@@ -539,3 +539,76 @@ describe("CloudBackend — migration on 404 + anonymous mirror", () => {
     assert.deepEqual(await b.read("demo:bounce"), {});
   });
 });
+
+describe("CloudBackend — write + debounce", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+  function makeFakeTimer() {
+    let pendingFn = null;
+    let pendingDelay = -1;
+    return {
+      setTimeout: (fn, ms) => { pendingFn = fn; pendingDelay = ms; return 1; },
+      clearTimeout: () => { pendingFn = null; pendingDelay = -1; },
+      run: async () => {
+        const fn = pendingFn;
+        pendingFn = null; pendingDelay = -1;
+        if (fn) await fn();
+      },
+      get pendingDelay() { return pendingDelay; },
+      get hasPending() { return pendingFn !== null; },
+    };
+  }
+
+  it("writes to mirror immediately and schedules a 1000ms push", async () => {
+    const storage = makeFakeStorage();
+    const timer = makeFakeTimer();
+    const fetchFn = async () => new Response(null, { status: 204 });
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, setTimeout: timer.setTimeout, clearTimeout: timer.clearTimeout,
+    });
+    b.write("demo:bounce", '{"hi":42}');
+    assert.equal(storage.getItem("mono:save:u1:demo:bounce"), '{"hi":42}');
+    assert.equal(timer.pendingDelay, 1000);
+  });
+
+  it("multiple writes within debounce collapse into one PUT", async () => {
+    const storage = makeFakeStorage();
+    const timer = makeFakeTimer();
+    const calls = [];
+    const fetchFn = async (url, init) => { calls.push(init); return new Response(null, { status: 204 }); };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, setTimeout: timer.setTimeout, clearTimeout: timer.clearTimeout,
+    });
+    b.write("demo:bounce", '{"hi":1}');
+    b.write("demo:bounce", '{"hi":2}');
+    b.write("demo:bounce", '{"hi":3}');
+    assert.ok(timer.hasPending);
+    await timer.run();
+    assert.equal(calls.length, 1);
+    assert.deepEqual(JSON.parse(calls[0].body), { bucket: { hi: 3 } });
+  });
+
+  it("network error on push leaves entry in pending for retry", async () => {
+    const storage = makeFakeStorage();
+    const timer = makeFakeTimer();
+    let attempts = 0;
+    const fetchFn = async () => { attempts++; throw new Error("offline"); };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, setTimeout: timer.setTimeout, clearTimeout: timer.clearTimeout,
+    });
+    b.write("demo:bounce", '{"hi":1}');
+    await timer.run();
+    assert.equal(attempts, 1);
+    assert.equal(b._pending.get("demo:bounce"), '{"hi":1}');
+  });
+});

--- a/runtime/save.test.mjs
+++ b/runtime/save.test.mjs
@@ -324,3 +324,50 @@ describe("WebBackend — native bridge path", () => {
     assert.throws(() => b.write("g", '{"v":1}'), /save: backend write failed/);
   });
 });
+
+describe("WebBackend — keyPrefix option", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+
+  it("defaults to 'mono:save:' when no keyPrefix is provided", () => {
+    const storage = makeFakeStorage();
+    const b = new MonoSave.WebBackend({ storage });
+    b.write("g", '{"v":1}');
+    assert.deepEqual(storage._entries(), [["mono:save:g", '{"v":1}']]);
+  });
+
+  it("uses a custom keyPrefix when supplied", () => {
+    const storage = makeFakeStorage();
+    const b = new MonoSave.WebBackend({ storage, keyPrefix: "mono:save:abc:" });
+    b.write("g", '{"v":1}');
+    assert.deepEqual(storage._entries(), [["mono:save:abc:g", '{"v":1}']]);
+  });
+
+  it("two backends with different prefixes do not collide", () => {
+    const storage = makeFakeStorage();
+    const a = new MonoSave.WebBackend({ storage, keyPrefix: "mono:save:" });
+    const u = new MonoSave.WebBackend({ storage, keyPrefix: "mono:save:user1:" });
+    a.write("hi", '{"a":1}');
+    u.write("hi", '{"a":2}');
+    assert.deepEqual(a.read("hi"), { a: 1 });
+    assert.deepEqual(u.read("hi"), { a: 2 });
+  });
+
+  it("clear respects the prefix", () => {
+    const storage = makeFakeStorage();
+    const a = new MonoSave.WebBackend({ storage, keyPrefix: "mono:save:" });
+    const u = new MonoSave.WebBackend({ storage, keyPrefix: "mono:save:user1:" });
+    a.write("hi", '{"a":1}');
+    u.write("hi", '{"a":2}');
+    u.clear("hi");
+    assert.deepEqual(a.read("hi"), { a: 1 });    // anon untouched
+    assert.deepEqual(u.read("hi"), {});          // user1 cleared
+  });
+});

--- a/runtime/save.test.mjs
+++ b/runtime/save.test.mjs
@@ -423,3 +423,60 @@ describe("CloudBackend — constructor + read happy path", () => {
     assert.deepEqual(JSON.parse(entries[0][1]), { hi: 7 });
   });
 });
+
+describe("CloudBackend — read failure paths", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+
+  it("returns {} on 404 when no anonymous mirror exists", async () => {
+    const fetchFn = async () => new Response(null, { status: 404 });
+    const storage = makeFakeStorage();
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage,
+    });
+    assert.deepEqual(await b.read("demo:bounce"), {});
+  });
+
+  it("falls back to per-uid mirror on network error", async () => {
+    const storage = makeFakeStorage();
+    storage.setItem("mono:save:u1:demo:bounce", '{"hi":99}');
+    const fetchFn = async () => { throw new Error("offline"); };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage,
+    });
+    assert.deepEqual(await b.read("demo:bounce"), { hi: 99 });
+  });
+
+  it("returns {} and warns once on 401", async () => {
+    const fetchFn = async () => new Response(null, { status: 401 });
+    const storage = makeFakeStorage();
+    const warnings = [];
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, warn: (m) => warnings.push(m),
+    });
+    assert.deepEqual(await b.read("demo:bounce"), {});
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /401/);
+  });
+
+  it("after 401 the backend is auth-dead (writes/clears no-op)", async () => {
+    // We won't fully exercise write yet (Task 8) — just verify the flag.
+    const fetchFn = async () => new Response(null, { status: 401 });
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage: makeFakeStorage(), warn: () => {},
+    });
+    await b.read("demo:bounce");
+    assert.equal(b._authDead, true);   // internal flag, exposed for test introspection
+  });
+});

--- a/runtime/save.test.mjs
+++ b/runtime/save.test.mjs
@@ -663,3 +663,77 @@ describe("CloudBackend — clear", () => {
     assert.equal(b._pending.has("demo:bounce"), false);
   });
 });
+
+describe("CloudBackend — keepalive flush on page leave", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+    };
+  }
+  function makeEventTarget() {
+    const handlers = {};
+    return {
+      addEventListener: (ev, fn) => { (handlers[ev] = handlers[ev] || []).push(fn); },
+      removeEventListener: () => {},
+      dispatchEvent: (ev) => { (handlers[ev.type] || []).forEach(fn => fn(ev)); },
+    };
+  }
+
+  it("registers visibilitychange + beforeunload listeners on construction", () => {
+    const target = makeEventTarget();
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: async () => new Response(null, { status: 204 }),
+      storage: makeFakeStorage(), setTimeout: () => 0, clearTimeout: () => {},
+      eventTarget: target, visibilityState: () => "visible",
+    });
+    // Bookkeeping: handlers were attached. (We don't expose them, but
+    // dispatching now should not throw.)
+    target.dispatchEvent({ type: "visibilitychange" });
+    target.dispatchEvent({ type: "beforeunload" });
+  });
+
+  it("issues a keepalive PUT for each pending entry on visibilitychange to hidden", async () => {
+    const target = makeEventTarget();
+    const calls = [];
+    const fetchFn = async (url, init) => { calls.push(init); return new Response(null, { status: 204 }); };
+    let visState = "visible";
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage: makeFakeStorage(),
+      setTimeout: () => 0, clearTimeout: () => {},
+      eventTarget: target, visibilityState: () => visState,
+    });
+    b.write("a", '{"v":1}');
+    b.write("b", '{"v":2}');
+    visState = "hidden";
+    target.dispatchEvent({ type: "visibilitychange" });
+    // Allow microtasks to drain.
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].keepalive, true);
+    assert.equal(calls[1].keepalive, true);
+  });
+
+  it("issues a keepalive PUT on beforeunload regardless of visibility", async () => {
+    const target = makeEventTarget();
+    const calls = [];
+    const fetchFn = async (url, init) => { calls.push(init); return new Response(null, { status: 204 }); };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage: makeFakeStorage(),
+      setTimeout: () => 0, clearTimeout: () => {},
+      eventTarget: target, visibilityState: () => "visible",
+    });
+    b.write("a", '{"v":1}');
+    target.dispatchEvent({ type: "beforeunload" });
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].keepalive, true);
+  });
+});

--- a/runtime/save.test.mjs
+++ b/runtime/save.test.mjs
@@ -538,6 +538,58 @@ describe("CloudBackend — migration on 404 + anonymous mirror", () => {
     });
     assert.deepEqual(await b.read("demo:bounce"), {});
   });
+
+  it("treats 200 with empty bucket as a migration trigger (anon recovery)", async () => {
+    // The worker repairs corrupt R2 records to {bucket: {}} for graceful
+    // UX. Without this guard, that repair would silently overwrite the
+    // anonymous mirror's data. 200 + empty + anon-has-data → migrate.
+    const storage = makeFakeStorage();
+    storage.setItem("mono:save:demo:bounce", '{"hi":42}');
+    let putBody = null;
+    const fetchFn = async (url, init) => {
+      if (init.method === "GET") return new Response(JSON.stringify({ bucket: {} }), { status: 200 });
+      if (init.method === "PUT") { putBody = init.body; return new Response(null, { status: 204 }); }
+      throw new Error("unexpected method");
+    };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage,
+      setTimeout: (fn) => { fn(); return 0; }, clearTimeout: () => {},
+    });
+    assert.deepEqual(await b.read("demo:bounce"), { hi: 42 });
+    await b._flushed;
+    assert.equal(storage.getItem("mono:save:u1:demo:bounce"), '{"hi":42}');
+    assert.deepEqual(JSON.parse(putBody), { bucket: { hi: 42 } });
+  });
+
+  it("falls back to mirror when getToken throws", async () => {
+    // Firebase getIdToken can reject on token-refresh blips. The boot
+    // must not die — the mirror has the last-known-good state.
+    const storage = makeFakeStorage();
+    storage.setItem("mono:save:u1:demo:bounce", '{"hi":99}');
+    const b = new MonoSave.CloudBackend({
+      uid: "u1",
+      getToken: async () => { throw new Error("token refresh blip"); },
+      apiUrl: "https://x",
+      fetch: async () => new Response(null, { status: 200 }),
+      storage, warn: () => {},
+      setTimeout: () => 0, clearTimeout: () => {},
+    });
+    assert.deepEqual(await b.read("demo:bounce"), { hi: 99 });
+  });
+
+  it("falls back to mirror when 200 body is corrupt JSON", async () => {
+    // res.json() can throw on flaky-proxy truncation. Don't take down boot.
+    const storage = makeFakeStorage();
+    storage.setItem("mono:save:u1:demo:bounce", '{"hi":7}');
+    const fetchFn = async () => new Response("{not json", { status: 200, headers: { "Content-Type": "application/json" } });
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, warn: () => {},
+      setTimeout: () => 0, clearTimeout: () => {},
+    });
+    assert.deepEqual(await b.read("demo:bounce"), { hi: 7 });
+  });
 });
 
 describe("CloudBackend — write + debounce", () => {

--- a/runtime/save.test.mjs
+++ b/runtime/save.test.mjs
@@ -371,3 +371,55 @@ describe("WebBackend — keyPrefix option", () => {
     assert.deepEqual(u.read("hi"), {});          // user1 cleared
   });
 });
+
+describe("CloudBackend — constructor + read happy path", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+
+  it("calls GET <apiUrl>/save/<cartId> with the bearer token", async () => {
+    const calls = [];
+    const fetchFn = async (url, init) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({ bucket: { hi: 7 } }), { status: 200 });
+    };
+    const storage = makeFakeStorage();
+    const b = new MonoSave.CloudBackend({
+      uid: "user1",
+      getToken: async () => "TOKEN",
+      apiUrl: "https://api.example.com",
+      fetch: fetchFn,
+      storage,
+    });
+    const out = await b.read("demo:bounce");
+    assert.deepEqual(out, { hi: 7 });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "https://api.example.com/save/demo%3Abounce");
+    assert.equal(calls[0].init.method, "GET");
+    assert.equal(calls[0].init.headers.Authorization, "Bearer TOKEN");
+  });
+
+  it("writes the returned bucket to the per-uid mirror", async () => {
+    const fetchFn = async () =>
+      new Response(JSON.stringify({ bucket: { hi: 7 } }), { status: 200 });
+    const storage = makeFakeStorage();
+    const b = new MonoSave.CloudBackend({
+      uid: "user1",
+      getToken: async () => "TOKEN",
+      apiUrl: "https://api.example.com",
+      fetch: fetchFn,
+      storage,
+    });
+    await b.read("demo:bounce");
+    const entries = storage._entries();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0][0], "mono:save:user1:demo:bounce");
+    assert.deepEqual(JSON.parse(entries[0][1]), { hi: 7 });
+  });
+});

--- a/runtime/save.test.mjs
+++ b/runtime/save.test.mjs
@@ -480,3 +480,57 @@ describe("CloudBackend — read failure paths", () => {
     assert.equal(b._authDead, true);   // internal flag, exposed for test introspection
   });
 });
+
+describe("CloudBackend — migration on 404 + anonymous mirror", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+
+  it("returns the anonymous bucket on 404 and writes it to the per-uid mirror", async () => {
+    const storage = makeFakeStorage();
+    storage.setItem("mono:save:demo:bounce", '{"hi":42}');   // anon mirror
+    let putBody = null;
+    const fetchFn = async (url, init) => {
+      if (init.method === "GET") return new Response(null, { status: 404 });
+      if (init.method === "PUT") { putBody = init.body; return new Response(null, { status: 204 }); }
+      throw new Error("unexpected method");
+    };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage,
+      // Inject setTimeout that runs immediately so the migration push happens synchronously for the test.
+      setTimeout: (fn) => { fn(); return 0; },
+      clearTimeout: () => {},
+    });
+    const out = await b.read("demo:bounce");
+    assert.deepEqual(out, { hi: 42 });
+
+    // Per-uid mirror now has the migrated data.
+    assert.equal(storage.getItem("mono:save:u1:demo:bounce"), '{"hi":42}');
+
+    // Anonymous mirror is preserved.
+    assert.equal(storage.getItem("mono:save:demo:bounce"), '{"hi":42}');
+
+    // Migration push was sent.
+    assert.ok(putBody, "expected a PUT to be issued for migration");
+    assert.deepEqual(JSON.parse(putBody), { bucket: { hi: 42 } });
+  });
+
+  it("returns {} on 404 when anonymous mirror is corrupt", async () => {
+    const storage = makeFakeStorage();
+    storage.setItem("mono:save:demo:bounce", "{not json");
+    const fetchFn = async () => new Response(null, { status: 404 });
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, warn: () => {},
+      setTimeout: (fn) => { fn(); return 0; }, clearTimeout: () => {},
+    });
+    assert.deepEqual(await b.read("demo:bounce"), {});
+  });
+});

--- a/runtime/save.test.mjs
+++ b/runtime/save.test.mjs
@@ -612,3 +612,54 @@ describe("CloudBackend — write + debounce", () => {
     assert.equal(b._pending.get("demo:bounce"), '{"hi":1}');
   });
 });
+
+describe("CloudBackend — clear", () => {
+  function makeFakeStorage() {
+    const map = new Map();
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => { map.set(k, String(v)); },
+      removeItem: (k) => { map.delete(k); },
+      _entries: () => Array.from(map.entries()),
+    };
+  }
+  function makeFakeTimer() {
+    let pendingFn = null;
+    return {
+      setTimeout: (fn) => { pendingFn = fn; return 1; },
+      clearTimeout: () => { pendingFn = null; },
+      get hasPending() { return pendingFn !== null; },
+    };
+  }
+
+  it("issues DELETE immediately and clears the per-uid mirror", async () => {
+    const storage = makeFakeStorage();
+    storage.setItem("mono:save:u1:demo:bounce", '{"hi":1}');
+    const calls = [];
+    const fetchFn = async (url, init) => { calls.push({ url, method: init.method }); return new Response(null, { status: 204 }); };
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, setTimeout: () => 0, clearTimeout: () => {},
+    });
+    await b.clear("demo:bounce");
+    assert.equal(storage.getItem("mono:save:u1:demo:bounce"), null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "DELETE");
+    assert.equal(calls[0].url, "https://x/save/demo%3Abounce");
+  });
+
+  it("cancels a pending push for the same cartId", async () => {
+    const storage = makeFakeStorage();
+    const timer = makeFakeTimer();
+    const fetchFn = async () => new Response(null, { status: 204 });
+    const b = new MonoSave.CloudBackend({
+      uid: "u1", getToken: async () => "T", apiUrl: "https://x",
+      fetch: fetchFn, storage, setTimeout: timer.setTimeout, clearTimeout: timer.clearTimeout,
+    });
+    b.write("demo:bounce", '{"hi":1}');
+    assert.ok(timer.hasPending);
+    await b.clear("demo:bounce");
+    // Pending push for this cartId must be gone.
+    assert.equal(b._pending.has("demo:bounce"), false);
+  });
+});

--- a/runtime/save.test.mjs
+++ b/runtime/save.test.mjs
@@ -511,6 +511,11 @@ describe("CloudBackend — migration on 404 + anonymous mirror", () => {
     const out = await b.read("demo:bounce");
     assert.deepEqual(out, { hi: 42 });
 
+    // The migration push is fire-and-forget; the synchronous setTimeout
+    // fixture invokes _flush() but discards the returned Promise. Drain
+    // it via _flushed so the PUT lands before we assert on it.
+    await b._flushed;
+
     // Per-uid mirror now has the migrated data.
     assert.equal(storage.getItem("mono:save:u1:demo:bounce"), '{"hi":42}');
 


### PR DESCRIPTION
## Summary

Builds on the local-save spec (PR #99) — adds a `CloudBackend` that syncs per-cart `data_*` save state to Cloudflare R2 for logged-in players, while keeping anonymous + headless flows on existing local backends.

- **`runtime/save.js`**: `WebBackend` gains `keyPrefix` option; new `CloudBackend` class composes a per-uid WebBackend mirror + debounced cloud push + keepalive flush on page leave + `dispose()` for listener cleanup. All transports injectable for tests.
- **`cosmi`**: three new authenticated routes — `GET/PUT/DELETE /save/:cartId` — with extracted handlers (`save-handlers.js`) and 12 fake-R2 unit tests. New `validateCartId` separates richer cartId namespace (`demo:bounce`, `pkg:foo`) from the existing R2 gameId rule.
- **`runtime/engine.js`**: `Mono.boot` accepts pre-built `opts.save = { backend, cartId }` so runners inject `CloudBackend` only when needed.
- **`runtime/engine-bindings.js`**: now `await`s `backend.read()` (was sync). Without this, async CloudBackend silently wiped saved data on every write — caught by final review, fixed before merge.
- **`play.html`**: new ESM block initializes Firebase, awaits auth state, constructs `CloudBackend` if signed in.
- **`dev/js/editor-play.js`**: reads `state.auth.currentUser`; disposes prior `CloudBackend` to avoid listener leak across editor resets.

**Decisions (from brainstorming):**
- Logged-in users on any cart → CloudBackend; anonymous → existing WebBackend (unchanged).
- First-login migration: cloud-wins when cloud has data; otherwise upload anonymous local. Anonymous local is **preserved**, never deleted — so logout returns to the pre-login state.
- Push: 1s debounce + `fetch keepalive` on `visibilitychange`/`beforeunload`.
- Auth detection: boot-time only (no live re-binding).
- R2 layout: `save/<uid>/<cartId>` with `{version, bucket, updated_at}` wrapper.

## Test Plan

- [x] `node --test runtime/save.test.mjs` → 61/61 (CloudBackend + WebBackend keyPrefix)
- [x] `cd cosmi && node --test test/*.test.mjs` → 105/105 (validateCartId 7 + save-handlers 12 + everything else)
- [x] All per-task subagent reviews (spec compliance + code quality) passed
- [x] Final integrated review caught C1 (engine-bindings missing await) — fixed in 18b3347 (sorry, last commit on branch)
- [ ] **Browser**: `play.html?game=save` while signed out — anonymous localStorage path works as before
- [ ] **Browser**: sign in, reload — cloud GET → mirror → bucket; subsequent saves debounce-PUT to cloud
- [ ] **Browser**: anonymous saves on a new device, then sign in for the first time — anonymous data uploads to cloud (cloud-empty case); anonymous localStorage entry still present
- [ ] **Browser**: open second browser/incognito with same account — saves from device 1 appear (cloud → fresh per-uid mirror)
- [ ] **Browser**: sign out — anonymous localStorage data reappears (logged-in mirror dormant)

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-03-cloud-save-design.md` (307 lines)
- Plan: `docs/superpowers/plans/2026-05-03-cloud-save.md` (1739 lines, 13 TDD tasks)
- Updates `docs/superpowers/specs/2026-05-02-local-save-design.md` future-work pointer

🤖 Generated with [Claude Code](https://claude.com/claude-code)